### PR TITLE
Add support for macOS.

### DIFF
--- a/Introspect-macOS/Info.plist
+++ b/Introspect-macOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2020 Lois Di Qual. All rights reserved.</string>
+</dict>
+</plist>

--- a/Introspect-macOS/Introspect_macOS.h
+++ b/Introspect-macOS/Introspect_macOS.h
@@ -1,0 +1,19 @@
+//
+//  Introspect_macOS.h
+//  Introspect-macOS
+//
+//  Created by Marcus Westin on 1/21/20.
+//  Copyright © 2020 Lois Di Qual. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for Introspect_macOS.
+FOUNDATION_EXPORT double Introspect_macOSVersionNumber;
+
+//! Project version string for Introspect_macOS.
+FOUNDATION_EXPORT const unsigned char Introspect_macOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Introspect_macOS/PublicHeader.h>
+
+

--- a/Introspect-macOSTests/Info.plist
+++ b/Introspect-macOSTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Introspect-macOSTests/Introspect_macOSTests.swift
+++ b/Introspect-macOSTests/Introspect_macOSTests.swift
@@ -1,0 +1,1 @@
+// See IntrospectTests.swift

--- a/Introspect.xcodeproj/project.pbxproj
+++ b/Introspect.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5F6C1C7323D77AD8001B1080 /* Introspect_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F6C1C6A23D77AD8001B1080 /* Introspect_macOS.framework */; };
+		5F6C1C7823D77AD8001B1080 /* Introspect_macOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6C1C7723D77AD8001B1080 /* Introspect_macOSTests.swift */; };
+		5F6C1C7A23D77AD8001B1080 /* Introspect_macOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F6C1C6C23D77AD8001B1080 /* Introspect_macOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5F6C1C8123D77AF5001B1080 /* IntrospectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0687030238DF3C900DAFD3D /* IntrospectTests.swift */; };
+		5F6C1C8223D77AF5001B1080 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = C068702E238DF01200DAFD3D /* TestUtils.swift */; };
+		5F6C1C8323D77B6C001B1080 /* Introspect.swift in Sources */ = {isa = PBXBuildFile; fileRef = C068702C238DE8FD00DAFD3D /* Introspect.swift */; };
 		C068701C238DE85D00DAFD3D /* Introspect.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0687012238DE85D00DAFD3D /* Introspect.framework */; };
 		C0687023238DE85D00DAFD3D /* Introspect.h in Headers */ = {isa = PBXBuildFile; fileRef = C0687015238DE85D00DAFD3D /* Introspect.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C068702D238DE8FD00DAFD3D /* Introspect.swift in Sources */ = {isa = PBXBuildFile; fileRef = C068702C238DE8FD00DAFD3D /* Introspect.swift */; };
@@ -23,6 +29,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		5F6C1C7423D77AD8001B1080 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C0687009238DE85D00DAFD3D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5F6C1C6923D77AD8001B1080;
+			remoteInfo = "Introspect-macOS";
+		};
 		C068701D238DE85D00DAFD3D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C0687009238DE85D00DAFD3D /* Project object */;
@@ -34,6 +47,12 @@
 
 /* Begin PBXFileReference section */
 		5785749C354BCF848BC4EAD9 /* Pods_IntrospectExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IntrospectExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5F6C1C6A23D77AD8001B1080 /* Introspect_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Introspect_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5F6C1C6C23D77AD8001B1080 /* Introspect_macOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Introspect_macOS.h; sourceTree = "<group>"; };
+		5F6C1C6D23D77AD8001B1080 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5F6C1C7223D77AD8001B1080 /* Introspect-macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Introspect-macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5F6C1C7723D77AD8001B1080 /* Introspect_macOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Introspect_macOSTests.swift; sourceTree = "<group>"; };
+		5F6C1C7923D77AD8001B1080 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9BBE78DB32CCDC560004DB54 /* Pods-IntrospectExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntrospectExamples.debug.xcconfig"; path = "Target Support Files/Pods-IntrospectExamples/Pods-IntrospectExamples.debug.xcconfig"; sourceTree = "<group>"; };
 		B826284199E111BBEA21E76B /* Pods-IntrospectExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntrospectExamples.release.xcconfig"; path = "Target Support Files/Pods-IntrospectExamples/Pods-IntrospectExamples.release.xcconfig"; sourceTree = "<group>"; };
 		C0687012238DE85D00DAFD3D /* Introspect.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Introspect.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,6 +74,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		5F6C1C6723D77AD8001B1080 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5F6C1C6F23D77AD8001B1080 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5F6C1C7323D77AD8001B1080 /* Introspect_macOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C068700F238DE85D00DAFD3D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -91,12 +125,32 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		5F6C1C6B23D77AD8001B1080 /* Introspect-macOS */ = {
+			isa = PBXGroup;
+			children = (
+				5F6C1C6C23D77AD8001B1080 /* Introspect_macOS.h */,
+				5F6C1C6D23D77AD8001B1080 /* Info.plist */,
+			);
+			path = "Introspect-macOS";
+			sourceTree = "<group>";
+		};
+		5F6C1C7623D77AD8001B1080 /* Introspect-macOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				5F6C1C7723D77AD8001B1080 /* Introspect_macOSTests.swift */,
+				5F6C1C7923D77AD8001B1080 /* Info.plist */,
+			);
+			path = "Introspect-macOSTests";
+			sourceTree = "<group>";
+		};
 		C0687008238DE85D00DAFD3D = {
 			isa = PBXGroup;
 			children = (
 				C0687014238DE85D00DAFD3D /* Introspect */,
 				C068701F238DE85D00DAFD3D /* IntrospectTests */,
 				C0C6D68C238E006B00DA6285 /* IntrospectExamples */,
+				5F6C1C6B23D77AD8001B1080 /* Introspect-macOS */,
+				5F6C1C7623D77AD8001B1080 /* Introspect-macOSTests */,
 				C0687013238DE85D00DAFD3D /* Products */,
 				C0C6D69F238E00D300DA6285 /* Frameworks */,
 				0534532308DF3E515053BF9F /* Pods */,
@@ -109,6 +163,8 @@
 				C0687012238DE85D00DAFD3D /* Introspect.framework */,
 				C068701B238DE85D00DAFD3D /* IntrospectTests.xctest */,
 				C0C6D68B238E006B00DA6285 /* IntrospectExamples.app */,
+				5F6C1C6A23D77AD8001B1080 /* Introspect_macOS.framework */,
+				5F6C1C7223D77AD8001B1080 /* Introspect-macOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -166,6 +222,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		5F6C1C6523D77AD8001B1080 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5F6C1C7A23D77AD8001B1080 /* Introspect_macOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C068700D238DE85D00DAFD3D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -177,6 +241,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		5F6C1C6923D77AD8001B1080 /* Introspect-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5F6C1C7F23D77AD8001B1080 /* Build configuration list for PBXNativeTarget "Introspect-macOS" */;
+			buildPhases = (
+				5F6C1C6523D77AD8001B1080 /* Headers */,
+				5F6C1C6623D77AD8001B1080 /* Sources */,
+				5F6C1C6723D77AD8001B1080 /* Frameworks */,
+				5F6C1C6823D77AD8001B1080 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Introspect-macOS";
+			productName = "Introspect-macOS";
+			productReference = 5F6C1C6A23D77AD8001B1080 /* Introspect_macOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		5F6C1C7123D77AD8001B1080 /* Introspect-macOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5F6C1C8023D77AD8001B1080 /* Build configuration list for PBXNativeTarget "Introspect-macOSTests" */;
+			buildPhases = (
+				5F6C1C6E23D77AD8001B1080 /* Sources */,
+				5F6C1C6F23D77AD8001B1080 /* Frameworks */,
+				5F6C1C7023D77AD8001B1080 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5F6C1C7523D77AD8001B1080 /* PBXTargetDependency */,
+			);
+			name = "Introspect-macOSTests";
+			productName = "Introspect-macOSTests";
+			productReference = 5F6C1C7223D77AD8001B1080 /* Introspect-macOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C0687011238DE85D00DAFD3D /* Introspect */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C0687026238DE85D00DAFD3D /* Build configuration list for PBXNativeTarget "Introspect" */;
@@ -238,10 +338,16 @@
 		C0687009238DE85D00DAFD3D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1120;
+				LastSwiftUpdateCheck = 1130;
 				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = "Lois Di Qual";
 				TargetAttributes = {
+					5F6C1C6923D77AD8001B1080 = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
+					5F6C1C7123D77AD8001B1080 = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
 					C0687011238DE85D00DAFD3D = {
 						CreatedOnToolsVersion = 11.2.1;
 						LastSwiftMigration = 1120;
@@ -270,11 +376,27 @@
 				C0687011238DE85D00DAFD3D /* Introspect */,
 				C068701A238DE85D00DAFD3D /* IntrospectTests */,
 				C0C6D68A238E006B00DA6285 /* IntrospectExamples */,
+				5F6C1C6923D77AD8001B1080 /* Introspect-macOS */,
+				5F6C1C7123D77AD8001B1080 /* Introspect-macOSTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		5F6C1C6823D77AD8001B1080 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5F6C1C7023D77AD8001B1080 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C0687010238DE85D00DAFD3D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -344,6 +466,24 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		5F6C1C6623D77AD8001B1080 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5F6C1C8323D77B6C001B1080 /* Introspect.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5F6C1C6E23D77AD8001B1080 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5F6C1C8123D77AF5001B1080 /* IntrospectTests.swift in Sources */,
+				5F6C1C8223D77AF5001B1080 /* TestUtils.swift in Sources */,
+				5F6C1C7823D77AD8001B1080 /* Introspect_macOSTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C068700E238DE85D00DAFD3D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -374,6 +514,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		5F6C1C7523D77AD8001B1080 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5F6C1C6923D77AD8001B1080 /* Introspect-macOS */;
+			targetProxy = 5F6C1C7423D77AD8001B1080 /* PBXContainerItemProxy */;
+		};
 		C068701E238DE85D00DAFD3D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C0687011238DE85D00DAFD3D /* Introspect */;
@@ -393,6 +538,96 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		5F6C1C7B23D77AD8001B1080 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Introspect-macOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.loisdiqual.Introspect-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		5F6C1C7C23D77AD8001B1080 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Introspect-macOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.loisdiqual.Introspect-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		5F6C1C7D23D77AD8001B1080 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "Introspect-macOSTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.loisdiqual.Introspect-macOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		5F6C1C7E23D77AD8001B1080 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "Introspect-macOSTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.loisdiqual.Introspect-macOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		C0687024238DE85D00DAFD3D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -645,6 +880,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		5F6C1C7F23D77AD8001B1080 /* Build configuration list for PBXNativeTarget "Introspect-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5F6C1C7B23D77AD8001B1080 /* Debug */,
+				5F6C1C7C23D77AD8001B1080 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5F6C1C8023D77AD8001B1080 /* Build configuration list for PBXNativeTarget "Introspect-macOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5F6C1C7D23D77AD8001B1080 /* Debug */,
+				5F6C1C7E23D77AD8001B1080 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C068700C238DE85D00DAFD3D /* Build configuration list for PBXProject "Introspect" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -1,14 +1,110 @@
 import SwiftUI
 
+#if os(iOS)
+// MARK: - iOS type aliases
+public typealias OSView = UIView
+public typealias OSViewController = UIViewController
+public typealias OSViewRepresentable = UIViewRepresentable
+public typealias OSViewRepresentableContext = UIViewRepresentableContext
+public typealias OSViewControllerRepresentable = UIViewControllerRepresentable
+public typealias OSViewControllerRepresentableContext = UIViewControllerRepresentableContext
+
+public typealias OSTableView = UITableView
+public typealias OSScrollView = UIScrollView
+public typealias OSTextField = UITextField
+public typealias OSSwitch = UISwitch
+public typealias OSSlider = UISlider
+public typealias OSStepper = UIStepper
+public typealias OSDatePicker = UIDatePicker
+public typealias OSSegmentedControl = UISegmentedControl
+
+public typealias IntrospectionUIView = IntrospectionOSView
+public typealias IntrospectionUIViewController = IntrospectionOSViewController
+
+extension IntrospectionView: UIViewRepresentable {
+    public func makeUIView(context: UIViewRepresentableContext<IntrospectionView<TargetViewType>>) -> IntrospectionUIView {
+        return makeOSView(context: context)
+    }
+    public func updateUIView(_ view: IntrospectionUIView, context: UIViewRepresentableContext<IntrospectionView<TargetViewType>>) {
+        updateOSView(view, context: context)
+    }
+}
+
+extension IntrospectionViewController: UIViewControllerRepresentable {
+    public func makeUIViewController(context: UIViewControllerRepresentableContext<IntrospectionViewController>) -> IntrospectionUIViewController {
+        return makeOSViewController(context: context)
+    }
+    public func updateUIViewController(_ viewController: IntrospectionOSViewController, context: UIViewControllerRepresentableContext<IntrospectionViewController>) {
+        updateOSViewController(viewController, context: context)
+    }
+}
+
+private extension UIView {
+    func setAccessibilityLabel(_ label: String?) { self.accessibilityLabel = label }
+}
+private extension UIViewController {
+    func setAccessibilityLabel(_ label: String?) { self.accessibilityLabel = label }
+}
+
+#elseif os(macOS)
+// MARK: - macOS type aliases
+public typealias OSView = NSView
+public typealias OSViewController = NSViewController
+public typealias OSViewRepresentable = NSViewRepresentable
+public typealias OSViewRepresentableContext = NSViewRepresentableContext
+public typealias OSViewControllerRepresentable = NSViewControllerRepresentable
+public typealias OSViewControllerRepresentableContext = NSViewControllerRepresentableContext
+
+public typealias OSTableView = NSTableView
+public typealias OSScrollView = NSScrollView
+public typealias OSTextField = NSTextField
+public typealias OSSwitch = NSSwitch
+public typealias OSSlider = NSSlider
+public typealias OSStepper = NSStepper
+public typealias OSDatePicker = NSDatePicker
+public typealias OSSegmentedControl = NSSegmentedControl
+
+public typealias IntrospectionNSView = IntrospectionOSView
+public typealias IntrospectionNSViewController = IntrospectionOSViewController
+
+extension IntrospectionView: NSViewRepresentable {
+    public func makeNSView(context: NSViewRepresentableContext<IntrospectionView<TargetViewType>>) -> IntrospectionNSView {
+        return makeOSView(context: context)
+    }
+    public func updateNSView(_ view: IntrospectionNSView, context: NSViewRepresentableContext<IntrospectionView<TargetViewType>>) {
+        updateOSView(view, context: context)
+    }
+}
+
+extension IntrospectionViewController: NSViewControllerRepresentable {
+    public func makeNSViewController(context: NSViewControllerRepresentableContext<IntrospectionViewController>) -> IntrospectionNSViewController {
+        return makeOSViewController(context: context)
+    }
+    public func updateNSViewController(_ viewController: IntrospectionOSViewController, context: NSViewControllerRepresentableContext<IntrospectionViewController>) {
+        updateOSViewController(viewController, context: context)
+    }
+}
+
+private extension NSViewController {
+    func setAccessibilityLabel(_ label: String?) { /* Not supported on macOS */ }
+}
+
+#else
+let _ = { fatalError("Unsupported os") }()
+#endif
+
+
+// MARK: - Platform independent implemntation
+
 /// Utility methods to inspect the UIKit view hierarchy.
 public enum Introspect {
     
     /// Finds a subview of the specified type.
     /// This method will recursively look for this view.
     /// Returns nil if it can't find a view of the specified type.
-    public static func findChild<AnyViewType: UIView>(
+    public static func findChild<AnyViewType: OSView>(
         ofType type: AnyViewType.Type,
-        in root: UIView
+        in root: OSView
     ) -> AnyViewType? {
         for subview in root.subviews {
             if let typed = subview as? AnyViewType {
@@ -23,9 +119,9 @@ public enum Introspect {
     /// Finds a child view controller of the specified type.
     /// This method will recursively look for this child.
     /// Returns nil if it can't find a view of the specified type.
-    public static func findChild<AnyViewControllerType: UIViewController>(
+    public static func findChild<AnyViewControllerType: OSViewController>(
         ofType type: AnyViewControllerType.Type,
-        in root: UIViewController
+        in root: OSViewController
     ) -> AnyViewControllerType? {
         for child in root.children {
             if let typed = child as? AnyViewControllerType {
@@ -40,9 +136,9 @@ public enum Introspect {
     /// Finds a previous sibling that contains a view of the specified type.
     /// This method inspects siblings recursively.
     /// Returns nil if no sibling contains the specified type.
-    public static func previousSibling<AnyViewType: UIView>(
+    public static func previousSibling<AnyViewType: OSView>(
         containing type: AnyViewType.Type,
-        from entry: UIView
+        from entry: OSView
     ) -> AnyViewType? {
         
         guard let superview = entry.superview,
@@ -64,9 +160,9 @@ public enum Introspect {
     /// Finds a previous sibling that contains a view controller of the specified type.
     /// This method inspects siblings recursively.
     /// Returns nil if no sibling contains the specified type.
-    public static func previousSibling<AnyViewControllerType: UIViewController>(
+    public static func previousSibling<AnyViewControllerType: OSViewController>(
         containing type: AnyViewControllerType.Type,
-        from entry: UIViewController
+        from entry: OSViewController
     ) -> AnyViewControllerType? {
         
         guard let parent = entry.parent,
@@ -88,9 +184,9 @@ public enum Introspect {
     /// Finds a previous sibling that is a view controller of the specified type.
     /// This method does not inspect siblings recursively.
     /// Returns nil if no sibling is of the specified type.
-    public static func previousSibling<AnyViewControllerType: UIViewController>(
+    public static func previousSibling<AnyViewControllerType: OSViewController>(
         ofType type: AnyViewControllerType.Type,
-        from entry: UIViewController
+        from entry: OSViewController
     ) -> AnyViewControllerType? {
         
         guard let parent = entry.parent,
@@ -112,9 +208,9 @@ public enum Introspect {
     /// Finds a next sibling that contains a view of the specified type.
     /// This method inspects siblings recursively.
     /// Returns nil if no sibling contains the specified type.
-    public static func nextSibling<AnyViewType: UIView>(
+    public static func nextSibling<AnyViewType: OSView>(
         containing type: AnyViewType.Type,
-        from entry: UIView
+        from entry: OSView
     ) -> AnyViewType? {
         
         guard let superview = entry.superview,
@@ -134,7 +230,7 @@ public enum Introspect {
     
     /// Finds an ancestor of the specified type.
     /// If it reaches the top of the view without finding the specified view type, it returns nil.
-    public static func findAncestor<AnyViewType: UIView>(ofType type: AnyViewType.Type, from entry: UIView) -> AnyViewType? {
+    public static func findAncestor<AnyViewType: OSView>(ofType type: AnyViewType.Type, from entry: OSView) -> AnyViewType? {
         var superview = entry.superview
         while let s = superview {
             if let typed = s as? AnyViewType {
@@ -149,7 +245,7 @@ public enum Introspect {
     /// Hosting views generally contain subviews for one specific SwiftUI element.
     /// For instance, if there are multiple text fields in a VStack, the hosting view will contain those text fields (and their host views, see below).
     /// Returns nil if it couldn't find a hosting view. This should never happen when called with an IntrospectionView.
-    public static func findHostingView(from entry: UIView) -> UIView? {
+    public static func findHostingView(from entry: OSView) -> OSView? {
         var superview = entry.superview
         while let s = superview {
             if NSStringFromClass(type(of: s)).contains("UIHostingView") {
@@ -161,9 +257,9 @@ public enum Introspect {
     }
     
     /// Finds the view host of a specific view.
-    /// SwiftUI wraps each UIView within a ViewHost, then within a HostingView.
+    /// SwiftUI wraps each OSView within a ViewHost, then within a HostingView.
     /// Returns nil if it couldn't find a view host. This should never happen when called with an IntrospectionView.
-    public static func findViewHost(from entry: UIView) -> UIView? {
+    public static func findViewHost(from entry: OSView) -> OSView? {
         var superview = entry.superview
         while let s = superview {
             if NSStringFromClass(type(of: s)).contains("ViewHost") {
@@ -187,14 +283,23 @@ private extension Array {
     }
 }
 
-/// Introspection UIView that is inserted alongside the target view.
-public class IntrospectionUIView: UIView {
+/// Introspection OSView that is inserted alongside the target view.
+public class IntrospectionOSView: OSView {
     
     required init() {
         super.init(frame: .zero)
         isHidden = true
+        
+        #if os(iOS) // Disable user interaction for iOS
         isUserInteractionEnabled = false
+        #endif
     }
+    
+    #if os(macOS) // Disable user interaction for macOS
+    public override func hitTest(_ point: NSPoint) -> NSView? {
+        return nil
+    }
+    #endif
     
     @available(*, unavailable)
     required init?(coder: NSCoder) {
@@ -203,41 +308,41 @@ public class IntrospectionUIView: UIView {
 }
 
 /// Introspection View that is injected into the UIKit hierarchy alongside the target view.
-/// After `updateUIView` is called, it calls `selector` to find the target view, then `customize` when the target view is found.
-public struct IntrospectionView<TargetViewType: UIView>: UIViewRepresentable {
+/// After `updateOSView` is called, it calls `selector` to find the target view, then `customize` when the target view is found.
+public struct IntrospectionView<TargetViewType: OSView> {
     
     /// Method that introspects the view hierarchy to find the target view.
     /// First argument is the introspection view itself, which is contained in a view host alongside the target view.
-    let selector: (IntrospectionUIView) -> TargetViewType?
+    let selector: (IntrospectionOSView) -> TargetViewType?
     
     /// User-provided customization method for the target view.
     let customize: (TargetViewType) -> Void
     
     public init(
-        selector: @escaping (UIView) -> TargetViewType?,
+        selector: @escaping (OSView) -> TargetViewType?,
         customize: @escaping (TargetViewType) -> Void
     ) {
         self.selector = selector
         self.customize = customize
     }
     
-    public func makeUIView(context: UIViewRepresentableContext<IntrospectionView>) -> IntrospectionUIView {
-        let view = IntrospectionUIView()
-        view.accessibilityLabel = "IntrospectionUIView<\(TargetViewType.self)>"
+    public func makeOSView(context: OSViewRepresentableContext<IntrospectionView>) -> IntrospectionOSView {
+        let view = IntrospectionOSView()
+        view.setAccessibilityLabel("IntrospectionOSView<\(TargetViewType.self)>")
         return view
     }
 
-    /// When `updateUiView` is called after creating the Introspection view, it is not yet in the UIKit hierarchy.
+    /// When `updateOSView` is called after creating the Introspection view, it is not yet in the UIKit hierarchy.
     /// At this point, `introspectionView.superview.superview` is nil and we can't access the target UIKit view.
     /// To workaround this, we wait until the runloop is done inserting the introspection view in the hierarchy, then run the selector.
-    /// Finding the target view fails silently if the selector yield no result. This happens when `updateUIView`
+    /// Finding the target view fails silently if the selector yield no result. This happens when `updateOSView`
     /// gets called when the introspection view gets removed from the hierarchy.
-    public func updateUIView(
-        _ uiView: IntrospectionUIView,
-        context: UIViewRepresentableContext<IntrospectionView>
+    public func updateOSView(
+        _ osView: IntrospectionOSView,
+        context: OSViewRepresentableContext<IntrospectionView>
     ) {
         DispatchQueue.main.asyncAfter(deadline: .now()) {
-            guard let targetView = self.selector(uiView) else {
+            guard let targetView = self.selector(osView) else {
                 return
             }
             self.customize(targetView)
@@ -245,11 +350,11 @@ public struct IntrospectionView<TargetViewType: UIView>: UIViewRepresentable {
     }
 }
 
-/// Introspection UIViewController that is inserted alongside the target view controller.
-public class IntrospectionUIViewController: UIViewController {
+/// Introspection OSViewController that is inserted alongside the target view controller.
+public class IntrospectionOSViewController: OSViewController {
     required init() {
         super.init(nibName: nil, bundle: nil)
-        view = IntrospectionUIView()
+        view = IntrospectionOSView()
     }
     
     @available(*, unavailable)
@@ -259,34 +364,34 @@ public class IntrospectionUIViewController: UIViewController {
 }
 
 /// This is the same logic as IntrospectionView but for view controllers. Please see details above.
-public struct IntrospectionViewController<TargetViewControllerType: UIViewController>: UIViewControllerRepresentable {
+public struct IntrospectionViewController<TargetViewControllerType: OSViewController> {
     
-    let selector: (IntrospectionUIViewController) -> TargetViewControllerType?
+    let selector: (IntrospectionOSViewController) -> TargetViewControllerType?
     let customize: (TargetViewControllerType) -> Void
     
     public init(
-        selector: @escaping (UIViewController) -> TargetViewControllerType?,
+        selector: @escaping (OSViewController) -> TargetViewControllerType?,
         customize: @escaping (TargetViewControllerType) -> Void
     ) {
         self.selector = selector
         self.customize = customize
     }
     
-    public func makeUIViewController(
-        context: UIViewControllerRepresentableContext<IntrospectionViewController>
-    ) -> IntrospectionUIViewController {
-        let viewController = IntrospectionUIViewController()
-        viewController.accessibilityLabel = "IntrospectionUIViewController<\(TargetViewControllerType.self)>"
-        viewController.view.accessibilityLabel = "IntrospectionUIView<\(TargetViewControllerType.self)>"
+    public func makeOSViewController(
+        context: OSViewControllerRepresentableContext<IntrospectionViewController>
+    ) -> IntrospectionOSViewController {
+        let viewController = IntrospectionOSViewController()
+        viewController.setAccessibilityLabel("IntrospectionOSViewController<\(TargetViewControllerType.self)>")
+        viewController.view.setAccessibilityLabel("IntrospectionOSView<\(TargetViewControllerType.self)>")
         return viewController
     }
     
-    public func updateUIViewController(
-        _ uiViewController: IntrospectionUIViewController,
-        context: UIViewControllerRepresentableContext<IntrospectionViewController>
+    public func updateOSViewController(
+        _ osViewController: IntrospectionOSViewController,
+        context: OSViewControllerRepresentableContext<IntrospectionViewController>
     ) {
         DispatchQueue.main.asyncAfter(deadline: .now()) {
-            guard let targetView = self.selector(uiViewController) else {
+            guard let targetView = self.selector(osViewController) else {
                 return
             }
             self.customize(targetView)
@@ -301,13 +406,15 @@ extension View {
         return overlay(view.frame(width: 0, height: 0))
     }
     
-    /// Finds a `UITableView` from a `SwiftUI.List`, or `SwiftUI.List` child.
-    public func introspectTableView(customize: @escaping (UITableView) -> ()) -> some View {
+    // TODO: Enable and fix this for macOS
+    #if os(iOS)
+    /// Finds a `OSTableView` from a `SwiftUI.List`, or `SwiftUI.List` child.
+    public func introspectTableView(customize: @escaping (OSTableView) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
 
                 // Search in ancestors
-                if let tableView = Introspect.findAncestor(ofType: UITableView.self, from: introspectionView) {
+                if let tableView = Introspect.findAncestor(ofType: OSTableView.self, from: introspectionView) {
                     return tableView
                 }
 
@@ -316,19 +423,20 @@ extension View {
                 }
 
                 // Search in siblings
-                return Introspect.previousSibling(containing: UITableView.self, from: viewHost)
+                return Introspect.previousSibling(containing: OSTableView.self, from: viewHost)
             },
             customize: customize
         ))
     }
+    #endif
     
-    /// Finds a `UIScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
-    public func introspectScrollView(customize: @escaping (UIScrollView) -> ()) -> some View {
+    /// Finds a `OSScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
+    public func introspectScrollView(customize: @escaping (OSScrollView) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 
                 // Search in ancestors
-                if let tableView = Introspect.findAncestor(ofType: UIScrollView.self, from: introspectionView) {
+                if let tableView = Introspect.findAncestor(ofType: OSScrollView.self, from: introspectionView) {
                     return tableView
                 }
                 
@@ -337,12 +445,13 @@ extension View {
                 }
                 
                 // Search in siblings
-                return Introspect.previousSibling(containing: UIScrollView.self, from: viewHost)
+                return Introspect.previousSibling(containing: OSScrollView.self, from: viewHost)
             },
             customize: customize
         ))
     }
     
+    #if os(iOS) // iOS Only
     /// Finds a `UINavigationController` from any view embedded in a `SwiftUI.NavigationView`.
     public func introspectNavigationController(customize: @escaping (UINavigationController) -> ()) -> some View {
         return inject(IntrospectionViewController(
@@ -360,8 +469,8 @@ extension View {
         ))
     }
     
-    /// Finds the containing `UIViewController` of a SwiftUI view.
-    public func introspectViewController(customize: @escaping (UIViewController) -> ()) -> some View {
+    /// Finds the containing `OSViewController` of a SwiftUI view.
+    public func introspectViewController(customize: @escaping (OSViewController) -> ()) -> some View {
         return inject(IntrospectionViewController(
             selector: { $0.parent },
             customize: customize
@@ -384,80 +493,85 @@ extension View {
             customize: customize
         ))
     }
+    #endif
     
     /// Finds a `UITextField` from a `SwiftUI.TextField`
-    public func introspectTextField(customize: @escaping (UITextField) -> ()) -> some View {
+    public func introspectTextField(customize: @escaping (OSTextField) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UITextField.self, from: viewHost)
+                return Introspect.previousSibling(containing: OSTextField.self, from: viewHost)
             },
             customize: customize
         ))
     }
     
-    /// Finds a `UISwitch` from a `SwiftUI.Toggle`
-    public func introspectSwitch(customize: @escaping (UISwitch) -> ()) -> some View {
+    
+     // TODO: Enable and fix this for macOS
+    #if os(iOS)
+    /// Finds a `OSSwitch` from a `SwiftUI.Toggle`
+    public func introspectSwitch(customize: @escaping (OSSwitch) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UISwitch.self, from: viewHost)
+                return Introspect.previousSibling(containing: OSSwitch.self, from: viewHost)
+            },
+            customize: customize
+        ))
+    }
+    #endif
+    
+    /// Finds a `OSSlider` from a `SwiftUI.Slider`
+    public func introspectSlider(customize: @escaping (OSSlider) -> ()) -> some View {
+        return inject(IntrospectionView(
+            selector: { introspectionView in
+                guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
+                    return nil
+                }
+                return Introspect.previousSibling(containing: OSSlider.self, from: viewHost)
             },
             customize: customize
         ))
     }
     
-    /// Finds a `UISlider` from a `SwiftUI.Slider`
-    public func introspectSlider(customize: @escaping (UISlider) -> ()) -> some View {
+    /// Finds a `OSStepper` from a `SwiftUI.Stepper`
+    public func introspectStepper(customize: @escaping (OSStepper) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UISlider.self, from: viewHost)
+                return Introspect.previousSibling(containing: OSStepper.self, from: viewHost)
             },
             customize: customize
         ))
     }
     
-    /// Finds a `UIStepper` from a `SwiftUI.Stepper`
-    public func introspectStepper(customize: @escaping (UIStepper) -> ()) -> some View {
+    /// Finds a `OSDatePicker` from a `SwiftUI.DatePicker`
+    public func introspectDatePicker(customize: @escaping (OSDatePicker) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UIStepper.self, from: viewHost)
+                return Introspect.previousSibling(containing: OSDatePicker.self, from: viewHost)
             },
             customize: customize
         ))
     }
     
-    /// Finds a `UIDatePicker` from a `SwiftUI.DatePicker`
-    public func introspectDatePicker(customize: @escaping (UIDatePicker) -> ()) -> some View {
+    /// Finds a `OSSegmentedControl` from a `SwiftUI.Picker` with style `SegmentedPickerStyle`
+    public func introspectSegmentedControl(customize: @escaping (OSSegmentedControl) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UIDatePicker.self, from: viewHost)
-            },
-            customize: customize
-        ))
-    }
-    
-    /// Finds a `UISegmentedControl` from a `SwiftUI.Picker` with style `SegmentedPickerStyle`
-    public func introspectSegmentedControl(customize: @escaping (UISegmentedControl) -> ()) -> some View {
-        return inject(IntrospectionView(
-            selector: { introspectionView in
-                guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
-                    return nil
-                }
-                return Introspect.previousSibling(containing: UISegmentedControl.self, from: viewHost)
+                return Introspect.previousSibling(containing: OSSegmentedControl.self, from: viewHost)
             },
             customize: customize
         ))

--- a/IntrospectTests/IntrospectTests.swift
+++ b/IntrospectTests/IntrospectTests.swift
@@ -1,8 +1,18 @@
 import XCTest
 import SwiftUI
 
+#if os(iOS)
 @testable import Introspect
+#elseif os(macOS)
+@testable import Introspect_macOS
+#endif
 
+// TODO: The following inspections could work in macOS. Fix them and re-enable the tests:
+// - testViewController
+// - testList
+// - testToggle
+
+#if os(iOS)
 private struct NavigationTestView: View {
     let spy: () -> Void
     var body: some View {
@@ -91,6 +101,7 @@ private struct ListTestView: View {
         }
     }
 }
+#endif
 
 private struct ScrollTestView: View {
     
@@ -126,6 +137,7 @@ private struct TextFieldTestView: View {
     }
 }
 
+#if os(iOS)
 private struct ToggleTestView: View {
     let spy: () -> Void
     @State private var toggleValue = false
@@ -136,6 +148,7 @@ private struct ToggleTestView: View {
         }
     }
 }
+#endif
 
 private struct SliderTestView: View {
     let spy: () -> Void
@@ -190,6 +203,7 @@ private struct SegmentedControlTestView: View {
 }
 
 class IntrospectTests: XCTestCase {
+    #if os(iOS)
     func testNavigation() {
         
         let expectation = XCTestExpectation()
@@ -251,7 +265,8 @@ class IntrospectTests: XCTestCase {
         TestUtils.present(view: view)
         wait(for: [expectation1, expectation2], timeout: 1)
     }
-    
+    #endif
+
     func testScrollView() {
         
         let expectation1 = XCTestExpectation()
@@ -274,6 +289,7 @@ class IntrospectTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
     
+    #if os(iOS)
     func testToggle() {
         
         let expectation = XCTestExpectation()
@@ -283,6 +299,7 @@ class IntrospectTests: XCTestCase {
         TestUtils.present(view: view)
         wait(for: [expectation], timeout: 1)
     }
+    #endif
     
     func testSlider() {
         

--- a/IntrospectTests/TestUtils.swift
+++ b/IntrospectTests/TestUtils.swift
@@ -1,6 +1,8 @@
 import Foundation
-import UIKit
 import SwiftUI
+
+#if os(iOS)
+import UIKit
 
 enum TestUtils {
     static func present<ViewType: View>(view: ViewType) {
@@ -24,3 +26,16 @@ enum TestUtils {
         hostingController.endAppearanceTransition()
     }
 }
+
+#elseif os(macOS)
+import AppKit
+
+enum TestUtils {
+    static func present<ViewType: View>(view: ViewType) {
+        let hostingController = NSHostingController(rootView: view)
+        let _ = NSWindow(contentViewController: hostingController)
+    }
+}
+
+#endif
+


### PR DESCRIPTION
This patch provides (partial) cross-platform functionality for macOS.

A few functions don't translate to macOS, such as introspection for `NavigationController`, `TabController`, etc - they have been conditionally excluded.

Three functions that should exist and work on macOS but currently do not are introspections for `ViewController`, `List`, and `Switch`. I expect that fixing them should be trivial, but I opted for creating one single porting commit to focus solely on getting cross-platform builds up and running.

Additional original commit details:

```
- Generalize the types in Introspect.swift to support both UIKit and AppKit (e.g OSView -> NS/UIView, etc)
- Create framework and test targets for macOS
- Implement test utility for macOS
- Conditionally exclude introspection functions that do not exist in AppKit (NavigationController, TabView, etc)
- Conditionally exclude introspection functions that should work for macOS but are currently not (ViewController, List and Switch)

TODO: Re-enable introspectSwitch, introspectViewController, and introspectTableView for macOS
TODO: Re-enable testViewController, testList, and testToggle for macOS
```