### PR TITLE
Add tvOS && macOS platform support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Introspect.podspec
+++ b/Introspect.podspec
@@ -10,6 +10,8 @@ Pod::Spec.new do |spec|
     tag: spec.version
   }
   spec.source_files = 'Introspect/**/*.swift'
-  spec.platform = :ios, '13.0'
+  spec.ios.deployment_target = '13.0'
+  spec.osx.deployment_target = '10.15'
+  spec.tvos.deployment_target = '13.0'
   spec.swift_version = '5.1'
 end

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -515,9 +515,7 @@ extension View {
         ))
     }
     
-    @available(OSX, unavailable)
     @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     /// Finds a `PlatformSwitch` from a `SwiftUI.Toggle`
     public func introspectSwitch(customize: @escaping (PlatformSwitch) -> ()) -> some View {
         return inject(IntrospectionView(
@@ -531,9 +529,7 @@ extension View {
         ))
     }
     
-    @available(OSX, unavailable)
     @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     /// Finds a `PlatformSlider` from a `SwiftUI.Slider`
     public func introspectSlider(customize: @escaping (PlatformSlider) -> ()) -> some View {
         return inject(IntrospectionView(
@@ -547,9 +543,7 @@ extension View {
         ))
     }
     
-    @available(OSX, unavailable)
     @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     /// Finds a `PlatformStepper` from a `SwiftUI.Stepper`
     public func introspectStepper(customize: @escaping (PlatformStepper) -> ()) -> some View {
         return inject(IntrospectionView(
@@ -563,9 +557,7 @@ extension View {
         ))
     }
     
-    @available(OSX, unavailable)
     @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     /// Finds a `PlatformDatePicker` from a `SwiftUI.DatePicker`
     public func introspectDatePicker(customize: @escaping (PlatformDatePicker) -> ()) -> some View {
         return inject(IntrospectionView(

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -463,6 +463,25 @@ extension View {
         ))
     }
     
+    #if os(iOS) || os(tvOS)
+    /// Finds a `UINavigationController` from any view embedded in a `SwiftUI.NavigationView`.
+    public func introspectNavigationController(customize: @escaping (UINavigationController) -> ()) -> some View {
+        return inject(IntrospectionViewController(
+            selector: { introspectionViewController in
+                
+                // Search in ancestors
+                if let navigationController = introspectionViewController.navigationController {
+                    return navigationController
+                }
+                
+                // Search in siblings
+                return Introspect.previousSibling(containing: UINavigationController.self, from: introspectionViewController)
+            },
+            customize: customize
+        ))
+    }
+    #endif
+    
     /// Finds the containing `UIViewController` of a SwiftUI view.
     public func introspectViewController(customize: @escaping (PlatformViewController) -> ()) -> some View {
         return inject(IntrospectionViewController(
@@ -484,25 +503,6 @@ extension View {
                 
                 // Search in siblings
                 return Introspect.previousSibling(ofType: UITabBarController.self, from: introspectionViewController)
-            },
-            customize: customize
-        ))
-    }
-    #endif
-    
-    #if os(iOS) || os(tvOS)
-    /// Finds a `UINavigationController` from any view embedded in a `SwiftUI.NavigationView`.
-    public func introspectNavigationController(customize: @escaping (UINavigationController) -> ()) -> some View {
-        return inject(IntrospectionViewController(
-            selector: { introspectionViewController in
-                
-                // Search in ancestors
-                if let navigationController = introspectionViewController.navigationController {
-                    return navigationController
-                }
-                
-                // Search in siblings
-                return Introspect.previousSibling(containing: UINavigationController.self, from: introspectionViewController)
             },
             customize: customize
         ))

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -1,43 +1,34 @@
 import SwiftUI
 
 #if os(macOS)
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias PlatformView = NSView
 #endif
 #if os(iOS) || os(tvOS)
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias PlatformView = UIView
 #endif
 
 #if os(macOS)
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias PlatformViewController = NSViewController
 #endif
 #if os(iOS) || os(tvOS)
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias PlatformViewController = UIViewController
 #endif
 
 #if os(macOS)
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias PlatformViewRepresentable = NSViewRepresentable
 #endif
 #if os(iOS) || os(tvOS)
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias PlatformViewRepresentable = UIViewRepresentable
 #endif
 
 #if os(macOS)
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias PlatformViewControllerRepresentable = NSViewControllerRepresentable
 #endif
 #if os(iOS) || os(tvOS)
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias PlatformViewControllerRepresentable = UIViewControllerRepresentable
 #endif
 
 #if os(macOS)
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias PlatformTableView = NSTableView
 public typealias PlatformScrollView = NSScrollView
 public typealias PlatformTextField = NSTextField
@@ -48,13 +39,16 @@ public typealias PlatformDatePicker = NSDatePicker
 public typealias PlatformSegmentedControl = NSSegmentedControl
 #endif
 #if os(iOS) || os(tvOS)
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias PlatformTableView = UITableView
 public typealias PlatformScrollView = UIScrollView
 public typealias PlatformTextField = UITextField
+@available(tvOS, unavailable)
 public typealias PlatformSwitch = UISwitch
+@available(tvOS, unavailable)
 public typealias PlatformSlider = UISlider
+@available(tvOS, unavailable)
 public typealias PlatformStepper = UIStepper
+@available(tvOS, unavailable)
 public typealias PlatformDatePicker = UIDatePicker
 public typealias PlatformSegmentedControl = UISegmentedControl
 #endif

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -221,7 +221,7 @@ public enum Introspect {
     }
     
     /// Finds the view host of a specific view.
-    /// SwiftUI wraps each PlatformView within a ViewHost, then within a HostingView.
+    /// SwiftUI wraps each UIView within a ViewHost, then within a HostingView.
     /// Returns nil if it couldn't find a view host. This should never happen when called with an IntrospectionView.
     public static func findViewHost(from entry: PlatformView) -> PlatformView? {
         var superview = entry.superview
@@ -247,7 +247,7 @@ private extension Array {
     }
 }
 
-/// Introspection PlatformView that is inserted alongside the target view.
+/// Introspection UIView that is inserted alongside the target view.
 public class IntrospectionPlatformView: PlatformView {
     
     required init() {
@@ -336,7 +336,7 @@ public struct IntrospectionView<TargetViewType: PlatformView>: PlatformViewRepre
     }
 }
 
-/// Introspection PlatformViewController that is inserted alongside the target view controller.
+/// Introspection UIViewController that is inserted alongside the target view controller.
 public class IntrospectionPlatformViewController: PlatformViewController {
     required init() {
         super.init(nibName: nil, bundle: nil)
@@ -414,7 +414,7 @@ extension View {
         return overlay(view.frame(width: 0, height: 0))
     }
     
-    /// Finds a `PlatformTableView` from a `SwiftUI.List`, or `SwiftUI.List` child.
+    /// Finds a `UITableView` from a `SwiftUI.List`, or `SwiftUI.List` child.
     public func introspectTableView(customize: @escaping (PlatformTableView) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
@@ -435,7 +435,7 @@ extension View {
         ))
     }
     
-    /// Finds a `PlatformScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
+    /// Finds a `UIScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
     public func introspectScrollView(customize: @escaping (PlatformScrollView) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
@@ -456,7 +456,7 @@ extension View {
         ))
     }
     
-    /// Finds the containing `PlatformViewController` of a SwiftUI view.
+    /// Finds the containing `UIViewController` of a SwiftUI view.
     public func introspectViewController(customize: @escaping (PlatformViewController) -> ()) -> some View {
         return inject(IntrospectionViewController(
             selector: { $0.parent },
@@ -502,7 +502,7 @@ extension View {
     }
     #endif
     
-    /// Finds a `PlatformTextField` from a `SwiftUI.TextField`
+    /// Finds a `UITextField` from a `SwiftUI.TextField`
     public func introspectTextField(customize: @escaping (PlatformTextField) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
@@ -516,7 +516,7 @@ extension View {
     }
     
     @available(tvOS, unavailable)
-    /// Finds a `PlatformSwitch` from a `SwiftUI.Toggle`
+    /// Finds a `UISwitch` from a `SwiftUI.Toggle`
     public func introspectSwitch(customize: @escaping (PlatformSwitch) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
@@ -530,7 +530,7 @@ extension View {
     }
     
     @available(tvOS, unavailable)
-    /// Finds a `PlatformSlider` from a `SwiftUI.Slider`
+    /// Finds a `UISlider` from a `SwiftUI.Slider`
     public func introspectSlider(customize: @escaping (PlatformSlider) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
@@ -544,7 +544,7 @@ extension View {
     }
     
     @available(tvOS, unavailable)
-    /// Finds a `PlatformStepper` from a `SwiftUI.Stepper`
+    /// Finds a `UIStepper` from a `SwiftUI.Stepper`
     public func introspectStepper(customize: @escaping (PlatformStepper) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
@@ -558,7 +558,7 @@ extension View {
     }
     
     @available(tvOS, unavailable)
-    /// Finds a `PlatformDatePicker` from a `SwiftUI.DatePicker`
+    /// Finds a `UIDatePicker` from a `SwiftUI.DatePicker`
     public func introspectDatePicker(customize: @escaping (PlatformDatePicker) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
@@ -571,7 +571,7 @@ extension View {
         ))
     }
     
-    /// Finds a `PlatformSegmentedControl` from a `SwiftUI.Picker` with style `SegmentedPickerStyle`
+    /// Finds a `UISegmentedControl` from a `SwiftUI.Picker` with style `SegmentedPickerStyle`
     public func introspectSegmentedControl(customize: @escaping (PlatformSegmentedControl) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -1,14 +1,74 @@
 import SwiftUI
 
+#if os(macOS)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias PlatformView = NSView
+#endif
+#if os(iOS) || os(tvOS)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias PlatformView = UIView
+#endif
+
+#if os(macOS)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias PlatformViewController = NSViewController
+#endif
+#if os(iOS) || os(tvOS)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias PlatformViewController = UIViewController
+#endif
+
+#if os(macOS)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias PlatformViewRepresentable = NSViewRepresentable
+#endif
+#if os(iOS) || os(tvOS)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias PlatformViewRepresentable = UIViewRepresentable
+#endif
+
+#if os(macOS)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias PlatformViewControllerRepresentable = NSViewControllerRepresentable
+#endif
+#if os(iOS) || os(tvOS)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias PlatformViewControllerRepresentable = UIViewControllerRepresentable
+#endif
+
+#if os(macOS)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias PlatformTableView = NSTableView
+public typealias PlatformScrollView = NSScrollView
+public typealias PlatformTextField = NSTextField
+public typealias PlatformSwitch = NSSwitch
+public typealias PlatformSlider = NSSlider
+public typealias PlatformStepper = NSStepper
+public typealias PlatformDatePicker = NSDatePicker
+public typealias PlatformSegmentedControl = NSSegmentedControl
+#endif
+#if os(iOS) || os(tvOS)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias PlatformTableView = UITableView
+public typealias PlatformScrollView = UIScrollView
+public typealias PlatformTextField = UITextField
+public typealias PlatformSwitch = UISwitch
+public typealias PlatformSlider = UISlider
+public typealias PlatformStepper = UIStepper
+public typealias PlatformDatePicker = UIDatePicker
+public typealias PlatformSegmentedControl = UISegmentedControl
+#endif
+
+
 /// Utility methods to inspect the UIKit view hierarchy.
 public enum Introspect {
     
     /// Finds a subview of the specified type.
     /// This method will recursively look for this view.
     /// Returns nil if it can't find a view of the specified type.
-    public static func findChild<AnyViewType: UIView>(
+    public static func findChild<AnyViewType: PlatformView>(
         ofType type: AnyViewType.Type,
-        in root: UIView
+        in root: PlatformView
     ) -> AnyViewType? {
         for subview in root.subviews {
             if let typed = subview as? AnyViewType {
@@ -23,9 +83,9 @@ public enum Introspect {
     /// Finds a child view controller of the specified type.
     /// This method will recursively look for this child.
     /// Returns nil if it can't find a view of the specified type.
-    public static func findChild<AnyViewControllerType: UIViewController>(
+    public static func findChild<AnyViewControllerType: PlatformViewController>(
         ofType type: AnyViewControllerType.Type,
-        in root: UIViewController
+        in root: PlatformViewController
     ) -> AnyViewControllerType? {
         for child in root.children {
             if let typed = child as? AnyViewControllerType {
@@ -40,9 +100,9 @@ public enum Introspect {
     /// Finds a previous sibling that contains a view of the specified type.
     /// This method inspects siblings recursively.
     /// Returns nil if no sibling contains the specified type.
-    public static func previousSibling<AnyViewType: UIView>(
+    public static func previousSibling<AnyViewType: PlatformView>(
         containing type: AnyViewType.Type,
-        from entry: UIView
+        from entry: PlatformView
     ) -> AnyViewType? {
         
         guard let superview = entry.superview,
@@ -64,9 +124,9 @@ public enum Introspect {
     /// Finds a previous sibling that contains a view controller of the specified type.
     /// This method inspects siblings recursively.
     /// Returns nil if no sibling contains the specified type.
-    public static func previousSibling<AnyViewControllerType: UIViewController>(
+    public static func previousSibling<AnyViewControllerType: PlatformViewController>(
         containing type: AnyViewControllerType.Type,
-        from entry: UIViewController
+        from entry: PlatformViewController
     ) -> AnyViewControllerType? {
         
         guard let parent = entry.parent,
@@ -88,9 +148,9 @@ public enum Introspect {
     /// Finds a previous sibling that is a view controller of the specified type.
     /// This method does not inspect siblings recursively.
     /// Returns nil if no sibling is of the specified type.
-    public static func previousSibling<AnyViewControllerType: UIViewController>(
+    public static func previousSibling<AnyViewControllerType: PlatformViewController>(
         ofType type: AnyViewControllerType.Type,
-        from entry: UIViewController
+        from entry: PlatformViewController
     ) -> AnyViewControllerType? {
         
         guard let parent = entry.parent,
@@ -112,9 +172,9 @@ public enum Introspect {
     /// Finds a next sibling that contains a view of the specified type.
     /// This method inspects siblings recursively.
     /// Returns nil if no sibling contains the specified type.
-    public static func nextSibling<AnyViewType: UIView>(
+    public static func nextSibling<AnyViewType: PlatformView>(
         containing type: AnyViewType.Type,
-        from entry: UIView
+        from entry: PlatformView
     ) -> AnyViewType? {
         
         guard let superview = entry.superview,
@@ -134,7 +194,7 @@ public enum Introspect {
     
     /// Finds an ancestor of the specified type.
     /// If it reaches the top of the view without finding the specified view type, it returns nil.
-    public static func findAncestor<AnyViewType: UIView>(ofType type: AnyViewType.Type, from entry: UIView) -> AnyViewType? {
+    public static func findAncestor<AnyViewType: PlatformView>(ofType type: AnyViewType.Type, from entry: PlatformView) -> AnyViewType? {
         var superview = entry.superview
         while let s = superview {
             if let typed = s as? AnyViewType {
@@ -149,7 +209,7 @@ public enum Introspect {
     /// Hosting views generally contain subviews for one specific SwiftUI element.
     /// For instance, if there are multiple text fields in a VStack, the hosting view will contain those text fields (and their host views, see below).
     /// Returns nil if it couldn't find a hosting view. This should never happen when called with an IntrospectionView.
-    public static func findHostingView(from entry: UIView) -> UIView? {
+    public static func findHostingView(from entry: PlatformView) -> PlatformView? {
         var superview = entry.superview
         while let s = superview {
             if NSStringFromClass(type(of: s)).contains("UIHostingView") {
@@ -161,9 +221,9 @@ public enum Introspect {
     }
     
     /// Finds the view host of a specific view.
-    /// SwiftUI wraps each UIView within a ViewHost, then within a HostingView.
+    /// SwiftUI wraps each PlatformView within a ViewHost, then within a HostingView.
     /// Returns nil if it couldn't find a view host. This should never happen when called with an IntrospectionView.
-    public static func findViewHost(from entry: UIView) -> UIView? {
+    public static func findViewHost(from entry: PlatformView) -> PlatformView? {
         var superview = entry.superview
         while let s = superview {
             if NSStringFromClass(type(of: s)).contains("ViewHost") {
@@ -187,14 +247,22 @@ private extension Array {
     }
 }
 
-/// Introspection UIView that is inserted alongside the target view.
-public class IntrospectionUIView: UIView {
+/// Introspection PlatformView that is inserted alongside the target view.
+public class IntrospectionPlatformView: PlatformView {
     
     required init() {
         super.init(frame: .zero)
         isHidden = true
+        #if os(iOS) || os(tvOS)
         isUserInteractionEnabled = false
+        #endif
     }
+    
+    #if os(macOS)
+    public override func hitTest(_ point: NSPoint) -> NSView? {
+        return nil
+    }
+    #endif
     
     @available(*, unavailable)
     required init?(coder: NSCoder) {
@@ -204,40 +272,63 @@ public class IntrospectionUIView: UIView {
 
 /// Introspection View that is injected into the UIKit hierarchy alongside the target view.
 /// After `updateUIView` is called, it calls `selector` to find the target view, then `customize` when the target view is found.
-public struct IntrospectionView<TargetViewType: UIView>: UIViewRepresentable {
+public struct IntrospectionView<TargetViewType: PlatformView>: PlatformViewRepresentable {
     
     /// Method that introspects the view hierarchy to find the target view.
     /// First argument is the introspection view itself, which is contained in a view host alongside the target view.
-    let selector: (IntrospectionUIView) -> TargetViewType?
+    let selector: (IntrospectionPlatformView) -> TargetViewType?
     
     /// User-provided customization method for the target view.
     let customize: (TargetViewType) -> Void
     
     public init(
-        selector: @escaping (UIView) -> TargetViewType?,
+        selector: @escaping (PlatformView) -> TargetViewType?,
         customize: @escaping (TargetViewType) -> Void
     ) {
         self.selector = selector
         self.customize = customize
     }
     
-    public func makeUIView(context: UIViewRepresentableContext<IntrospectionView>) -> IntrospectionUIView {
-        let view = IntrospectionUIView()
-        view.accessibilityLabel = "IntrospectionUIView<\(TargetViewType.self)>"
+    #if os(iOS) || os(tvOS)
+    public func makeUIView(context: Context) -> IntrospectionPlatformView {
+        makeView(context: context)
+    }
+    #endif
+    #if os(macOS)
+    public func makeNSView(context: Context) -> IntrospectionPlatformView {
+        makeView(context: context)
+    }
+    #endif
+    
+    internal func makeView(context: Context) -> IntrospectionPlatformView {
+        let view = IntrospectionPlatformView()
+        #if os(iOS) || os(tvOS)
+        view.accessibilityLabel = "IntrospectionPlatformView<\(TargetViewType.self)>"
+        #else
+        view.setAccessibilityLabel("IntrospectionPlatformView<\(TargetViewType.self)>")
+        #endif
         return view
     }
+    
+    #if os(iOS) || os(tvOS)
+    public func updateUIView(_ uiView: IntrospectionPlatformView, context: Context) {
+        updateView(uiView, context: context)
+    }
+    #endif
+    #if os(macOS)
+    public func updateNSView(_ nsView: IntrospectionPlatformView, context: Context) {
+        updateView(nsView, context: context)
+    }
+    #endif
 
     /// When `updateUiView` is called after creating the Introspection view, it is not yet in the UIKit hierarchy.
     /// At this point, `introspectionView.superview.superview` is nil and we can't access the target UIKit view.
     /// To workaround this, we wait until the runloop is done inserting the introspection view in the hierarchy, then run the selector.
     /// Finding the target view fails silently if the selector yield no result. This happens when `updateUIView`
     /// gets called when the introspection view gets removed from the hierarchy.
-    public func updateUIView(
-        _ uiView: IntrospectionUIView,
-        context: UIViewRepresentableContext<IntrospectionView>
-    ) {
+    internal func updateView(_ view: IntrospectionPlatformView, context: Context) {
         DispatchQueue.main.asyncAfter(deadline: .now()) {
-            guard let targetView = self.selector(uiView) else {
+            guard let targetView = self.selector(view) else {
                 return
             }
             self.customize(targetView)
@@ -245,11 +336,11 @@ public struct IntrospectionView<TargetViewType: UIView>: UIViewRepresentable {
     }
 }
 
-/// Introspection UIViewController that is inserted alongside the target view controller.
-public class IntrospectionUIViewController: UIViewController {
+/// Introspection PlatformViewController that is inserted alongside the target view controller.
+public class IntrospectionPlatformViewController: PlatformViewController {
     required init() {
         super.init(nibName: nil, bundle: nil)
-        view = IntrospectionUIView()
+        view = IntrospectionPlatformView()
     }
     
     @available(*, unavailable)
@@ -259,34 +350,56 @@ public class IntrospectionUIViewController: UIViewController {
 }
 
 /// This is the same logic as IntrospectionView but for view controllers. Please see details above.
-public struct IntrospectionViewController<TargetViewControllerType: UIViewController>: UIViewControllerRepresentable {
+public struct IntrospectionViewController<TargetViewControllerType: PlatformViewController>: PlatformViewControllerRepresentable {
     
-    let selector: (IntrospectionUIViewController) -> TargetViewControllerType?
+    let selector: (IntrospectionPlatformViewController) -> TargetViewControllerType?
     let customize: (TargetViewControllerType) -> Void
     
     public init(
-        selector: @escaping (UIViewController) -> TargetViewControllerType?,
+        selector: @escaping (PlatformViewController) -> TargetViewControllerType?,
         customize: @escaping (TargetViewControllerType) -> Void
     ) {
         self.selector = selector
         self.customize = customize
     }
     
-    public func makeUIViewController(
-        context: UIViewControllerRepresentableContext<IntrospectionViewController>
-    ) -> IntrospectionUIViewController {
-        let viewController = IntrospectionUIViewController()
-        viewController.accessibilityLabel = "IntrospectionUIViewController<\(TargetViewControllerType.self)>"
-        viewController.view.accessibilityLabel = "IntrospectionUIView<\(TargetViewControllerType.self)>"
+    #if os(iOS) || os(tvOS)
+    public func makeUIViewController(context: Context) -> IntrospectionPlatformViewController {
+        makeViewController(context: context)
+    }
+    #endif
+    #if os(macOS)
+    public func makeNSViewController(context: Context) -> IntrospectionPlatformViewController {
+        makeViewController(context: context)
+    }
+    #endif
+    
+    internal func makeViewController(context: Context) -> IntrospectionPlatformViewController {
+        let viewController = IntrospectionPlatformViewController()
+        #if os(iOS) || os(tvOS)
+        viewController.accessibilityLabel = "IntrospectionPlatformViewController<\(TargetViewControllerType.self)>"
+        viewController.view.accessibilityLabel = "IntrospectionPlatformView<\(TargetViewControllerType.self)>"
+        #endif
+        #if os(macOS)
+        viewController.view.setAccessibilityLabel("IntrospectionPlatformView<\(TargetViewControllerType.self)>")
+        #endif
         return viewController
     }
     
-    public func updateUIViewController(
-        _ uiViewController: IntrospectionUIViewController,
-        context: UIViewControllerRepresentableContext<IntrospectionViewController>
-    ) {
+    #if os(iOS) || os(tvOS)
+    public func updateUIViewController(_ uiViewController: IntrospectionPlatformViewController, context: Context) {
+        updateViewController(uiViewController, context: context)
+    }
+    #endif
+    #if os(macOS)
+    public func updateNSViewController(_ nsViewController: IntrospectionPlatformViewController, context: Context) {
+        updateViewController(nsViewController, context: context)
+    }
+    #endif
+    
+    internal func updateViewController(_ viewController: IntrospectionPlatformViewController, context: Context) {
         DispatchQueue.main.asyncAfter(deadline: .now()) {
-            guard let targetView = self.selector(uiViewController) else {
+            guard let targetView = self.selector(viewController) else {
                 return
             }
             self.customize(targetView)
@@ -301,13 +414,13 @@ extension View {
         return overlay(view.frame(width: 0, height: 0))
     }
     
-    /// Finds a `UITableView` from a `SwiftUI.List`, or `SwiftUI.List` child.
-    public func introspectTableView(customize: @escaping (UITableView) -> ()) -> some View {
+    /// Finds a `PlatformTableView` from a `SwiftUI.List`, or `SwiftUI.List` child.
+    public func introspectTableView(customize: @escaping (PlatformTableView) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
 
                 // Search in ancestors
-                if let tableView = Introspect.findAncestor(ofType: UITableView.self, from: introspectionView) {
+                if let tableView = Introspect.findAncestor(ofType: PlatformTableView.self, from: introspectionView) {
                     return tableView
                 }
 
@@ -316,19 +429,19 @@ extension View {
                 }
 
                 // Search in siblings
-                return Introspect.previousSibling(containing: UITableView.self, from: viewHost)
+                return Introspect.previousSibling(containing: PlatformTableView.self, from: viewHost)
             },
             customize: customize
         ))
     }
     
-    /// Finds a `UIScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
-    public func introspectScrollView(customize: @escaping (UIScrollView) -> ()) -> some View {
+    /// Finds a `PlatformScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
+    public func introspectScrollView(customize: @escaping (PlatformScrollView) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 
                 // Search in ancestors
-                if let tableView = Introspect.findAncestor(ofType: UIScrollView.self, from: introspectionView) {
+                if let tableView = Introspect.findAncestor(ofType: PlatformScrollView.self, from: introspectionView) {
                     return tableView
                 }
                 
@@ -337,37 +450,21 @@ extension View {
                 }
                 
                 // Search in siblings
-                return Introspect.previousSibling(containing: UIScrollView.self, from: viewHost)
+                return Introspect.previousSibling(containing: PlatformScrollView.self, from: viewHost)
             },
             customize: customize
         ))
     }
     
-    /// Finds a `UINavigationController` from any view embedded in a `SwiftUI.NavigationView`.
-    public func introspectNavigationController(customize: @escaping (UINavigationController) -> ()) -> some View {
-        return inject(IntrospectionViewController(
-            selector: { introspectionViewController in
-                
-                // Search in ancestors
-                if let navigationController = introspectionViewController.navigationController {
-                    return navigationController
-                }
-                
-                // Search in siblings
-                return Introspect.previousSibling(containing: UINavigationController.self, from: introspectionViewController)
-            },
-            customize: customize
-        ))
-    }
-    
-    /// Finds the containing `UIViewController` of a SwiftUI view.
-    public func introspectViewController(customize: @escaping (UIViewController) -> ()) -> some View {
+    /// Finds the containing `PlatformViewController` of a SwiftUI view.
+    public func introspectViewController(customize: @escaping (PlatformViewController) -> ()) -> some View {
         return inject(IntrospectionViewController(
             selector: { $0.parent },
             customize: customize
         ))
     }
 
+    #if os(iOS) || os(tvOS)
     /// Finds a `UITabBarController` from any SwiftUI view embedded in a `SwiftUI.TabView`
     public func introspectTabBarController(customize: @escaping (UITabBarController) -> ()) -> some View {
         return inject(IntrospectionViewController(
@@ -384,15 +481,35 @@ extension View {
             customize: customize
         ))
     }
+    #endif
     
-    /// Finds a `UITextField` from a `SwiftUI.TextField`
-    public func introspectTextField(customize: @escaping (UITextField) -> ()) -> some View {
+    #if os(iOS) || os(tvOS)
+    /// Finds a `UINavigationController` from any view embedded in a `SwiftUI.NavigationView`.
+    public func introspectNavigationController(customize: @escaping (UINavigationController) -> ()) -> some View {
+        return inject(IntrospectionViewController(
+            selector: { introspectionViewController in
+                
+                // Search in ancestors
+                if let navigationController = introspectionViewController.navigationController {
+                    return navigationController
+                }
+                
+                // Search in siblings
+                return Introspect.previousSibling(containing: UINavigationController.self, from: introspectionViewController)
+            },
+            customize: customize
+        ))
+    }
+    #endif
+    
+    /// Finds a `PlatformTextField` from a `SwiftUI.TextField`
+    public func introspectTextField(customize: @escaping (PlatformTextField) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UITextField.self, from: viewHost)
+                return Introspect.previousSibling(containing: PlatformTextField.self, from: viewHost)
             },
             customize: customize
         ))
@@ -401,14 +518,14 @@ extension View {
     @available(OSX, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    /// Finds a `UISwitch` from a `SwiftUI.Toggle`
-    public func introspectSwitch(customize: @escaping (UISwitch) -> ()) -> some View {
+    /// Finds a `PlatformSwitch` from a `SwiftUI.Toggle`
+    public func introspectSwitch(customize: @escaping (PlatformSwitch) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UISwitch.self, from: viewHost)
+                return Introspect.previousSibling(containing: PlatformSwitch.self, from: viewHost)
             },
             customize: customize
         ))
@@ -417,14 +534,14 @@ extension View {
     @available(OSX, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    /// Finds a `UISlider` from a `SwiftUI.Slider`
-    public func introspectSlider(customize: @escaping (UISlider) -> ()) -> some View {
+    /// Finds a `PlatformSlider` from a `SwiftUI.Slider`
+    public func introspectSlider(customize: @escaping (PlatformSlider) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UISlider.self, from: viewHost)
+                return Introspect.previousSibling(containing: PlatformSlider.self, from: viewHost)
             },
             customize: customize
         ))
@@ -433,14 +550,14 @@ extension View {
     @available(OSX, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    /// Finds a `UIStepper` from a `SwiftUI.Stepper`
-    public func introspectStepper(customize: @escaping (UIStepper) -> ()) -> some View {
+    /// Finds a `PlatformStepper` from a `SwiftUI.Stepper`
+    public func introspectStepper(customize: @escaping (PlatformStepper) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UIStepper.self, from: viewHost)
+                return Introspect.previousSibling(containing: PlatformStepper.self, from: viewHost)
             },
             customize: customize
         ))
@@ -449,27 +566,27 @@ extension View {
     @available(OSX, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    /// Finds a `UIDatePicker` from a `SwiftUI.DatePicker`
-    public func introspectDatePicker(customize: @escaping (UIDatePicker) -> ()) -> some View {
+    /// Finds a `PlatformDatePicker` from a `SwiftUI.DatePicker`
+    public func introspectDatePicker(customize: @escaping (PlatformDatePicker) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UIDatePicker.self, from: viewHost)
+                return Introspect.previousSibling(containing: PlatformDatePicker.self, from: viewHost)
             },
             customize: customize
         ))
     }
     
-    /// Finds a `UISegmentedControl` from a `SwiftUI.Picker` with style `SegmentedPickerStyle`
-    public func introspectSegmentedControl(customize: @escaping (UISegmentedControl) -> ()) -> some View {
+    /// Finds a `PlatformSegmentedControl` from a `SwiftUI.Picker` with style `SegmentedPickerStyle`
+    public func introspectSegmentedControl(customize: @escaping (PlatformSegmentedControl) -> ()) -> some View {
         return inject(IntrospectionView(
             selector: { introspectionView in
                 guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
                     return nil
                 }
-                return Introspect.previousSibling(containing: UISegmentedControl.self, from: viewHost)
+                return Introspect.previousSibling(containing: PlatformSegmentedControl.self, from: viewHost)
             },
             customize: customize
         ))

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -212,9 +212,16 @@ public enum Introspect {
     public static func findHostingView(from entry: PlatformView) -> PlatformView? {
         var superview = entry.superview
         while let s = superview {
+            #if os(iOS) || os(tvOS)
             if NSStringFromClass(type(of: s)).contains("UIHostingView") {
                 return s
             }
+            #endif
+            #if os(macOS)
+            if NSStringFromClass(type(of: s)).contains("NSHostingView") {
+                return s
+            }
+            #endif
             superview = s.superview
         }
         return nil

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -398,6 +398,9 @@ extension View {
         ))
     }
     
+    @available(OSX, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     /// Finds a `UISwitch` from a `SwiftUI.Toggle`
     public func introspectSwitch(customize: @escaping (UISwitch) -> ()) -> some View {
         return inject(IntrospectionView(
@@ -411,6 +414,9 @@ extension View {
         ))
     }
     
+    @available(OSX, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     /// Finds a `UISlider` from a `SwiftUI.Slider`
     public func introspectSlider(customize: @escaping (UISlider) -> ()) -> some View {
         return inject(IntrospectionView(
@@ -424,6 +430,9 @@ extension View {
         ))
     }
     
+    @available(OSX, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     /// Finds a `UIStepper` from a `SwiftUI.Stepper`
     public func introspectStepper(customize: @escaping (UIStepper) -> ()) -> some View {
         return inject(IntrospectionView(
@@ -437,6 +446,9 @@ extension View {
         ))
     }
     
+    @available(OSX, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     /// Finds a `UIDatePicker` from a `SwiftUI.DatePicker`
     public func introspectDatePicker(customize: @escaping (UIDatePicker) -> ()) -> some View {
         return inject(IntrospectionView(

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Introspect",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Introspect",
     platforms: [
-        .iOS(.v13)
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
     ],
     products: [
         .library(


### PR DESCRIPTION
For tvOS, only disable the un-supported element like:

+ UISwitch
+ UIStepper
+ UISlider
+ UIDatePicker

For macOS, use the cross-platform typealias to make it work, disable the un-supported element like:

+ UITabBarController
+ UINavigationController

This fix #9 