### PR TITLE
Feature/generic ui view introspection

### DIFF
--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -398,6 +398,19 @@ extension View {
         ))
     }
     
+    /// Finds a `TargetView` from a `SwiftUI.View`
+    public func introspect<TargetView: UIView>(customize: @escaping (TargetView) -> ()) -> some View {
+        return inject(IntrospectionView(
+            selector: { introspectionView in
+                guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
+                    return nil
+                }
+                return Introspect.previousSibling(containing: TargetView.self, from: viewHost)
+            },
+            customize: customize
+        ))
+    }
+    
     /// Finds a `UISwitch` from a `SwiftUI.Toggle`
     public func introspectSwitch(customize: @escaping (UISwitch) -> ()) -> some View {
         return inject(IntrospectionView(

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -385,19 +385,6 @@ extension View {
         ))
     }
     
-    /// Finds a `UITextField` from a `SwiftUI.TextField`
-    public func introspectTextField(customize: @escaping (UITextField) -> ()) -> some View {
-        return inject(IntrospectionView(
-            selector: { introspectionView in
-                guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
-                    return nil
-                }
-                return Introspect.previousSibling(containing: UITextField.self, from: viewHost)
-            },
-            customize: customize
-        ))
-    }
-    
     /// Finds a `TargetView` from a `SwiftUI.View`
     public func introspect<TargetView: UIView>(customize: @escaping (TargetView) -> ()) -> some View {
         return inject(IntrospectionView(
@@ -411,68 +398,33 @@ extension View {
         ))
     }
     
+    /// Finds a `UITextField` from a `SwiftUI.TextField`
+    public func introspectTextField(customize: @escaping (UITextField) -> ()) -> some View {
+        return introspect(customize: customize)
+    }
+    
     /// Finds a `UISwitch` from a `SwiftUI.Toggle`
     public func introspectSwitch(customize: @escaping (UISwitch) -> ()) -> some View {
-        return inject(IntrospectionView(
-            selector: { introspectionView in
-                guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
-                    return nil
-                }
-                return Introspect.previousSibling(containing: UISwitch.self, from: viewHost)
-            },
-            customize: customize
-        ))
+        return introspect(customize: customize)
     }
     
     /// Finds a `UISlider` from a `SwiftUI.Slider`
     public func introspectSlider(customize: @escaping (UISlider) -> ()) -> some View {
-        return inject(IntrospectionView(
-            selector: { introspectionView in
-                guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
-                    return nil
-                }
-                return Introspect.previousSibling(containing: UISlider.self, from: viewHost)
-            },
-            customize: customize
-        ))
+        return introspect(customize: customize)
     }
     
     /// Finds a `UIStepper` from a `SwiftUI.Stepper`
     public func introspectStepper(customize: @escaping (UIStepper) -> ()) -> some View {
-        return inject(IntrospectionView(
-            selector: { introspectionView in
-                guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
-                    return nil
-                }
-                return Introspect.previousSibling(containing: UIStepper.self, from: viewHost)
-            },
-            customize: customize
-        ))
+        return introspect(customize: customize)
     }
     
     /// Finds a `UIDatePicker` from a `SwiftUI.DatePicker`
     public func introspectDatePicker(customize: @escaping (UIDatePicker) -> ()) -> some View {
-        return inject(IntrospectionView(
-            selector: { introspectionView in
-                guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
-                    return nil
-                }
-                return Introspect.previousSibling(containing: UIDatePicker.self, from: viewHost)
-            },
-            customize: customize
-        ))
+        return introspect(customize: customize)
     }
     
     /// Finds a `UISegmentedControl` from a `SwiftUI.Picker` with style `SegmentedPickerStyle`
     public func introspectSegmentedControl(customize: @escaping (UISegmentedControl) -> ()) -> some View {
-        return inject(IntrospectionView(
-            selector: { introspectionView in
-                guard let viewHost = Introspect.findViewHost(from: introspectionView) else {
-                    return nil
-                }
-                return Introspect.previousSibling(containing: UISegmentedControl.self, from: viewHost)
-            },
-            customize: customize
-        ))
+        return introspect(customize: customize)
     }
 }


### PR DESCRIPTION
First off, thanks for the very nice lib. It's been very useful for me.

1. I've added a new selector which should make it easier to introspect for views that don't have a selector yet. It leverages introspection and can be used like this:

```
// Considering `introspectTextField` didn't exist yet:

AnyView()
    .introspect(customize: { (textField: UITextField) in
        print("Found textfield \(textField)")
    })
```

2. Since quite some code was basically don't the exact same as the newly introduced generic method, I have replaced that with a call to the new method.
2.1 Feel free to reject this commit, I can easily revert it for you.

I've tested the above and as far as I've seen, it works.
