### PR TITLE
Support building for Catalyst on the Mac

### DIFF
--- a/Introspect/AppKitIntrospectionView.swift
+++ b/Introspect/AppKitIntrospectionView.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import SwiftUI
 import AppKit
 

--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -114,7 +114,7 @@ extension View {
 }
 #endif
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 extension View {
     
     /// Finds a `TargetView` from a `SwiftUI.View`


### PR DESCRIPTION
When building for Catalyst on the Mac, `canImport(AppKit)` is true, so you also need to check for `!targetEnvironment(macCatalyst)`.