### PR TITLE
Fix: Introspector in iOS 14 not working for ScrollView (#55)

### DIFF
--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -51,7 +51,7 @@ public enum Introspect {
         return nil
     }
     
-    /// Finds a previous sibling that contains a view of the specified type.
+    /// Finds a previous sibling that is or contains a view of the specified type.
     /// This method inspects siblings recursively.
     /// Returns nil if no sibling contains the specified type.
     public static func previousSibling<AnyViewType: PlatformView>(
@@ -67,6 +67,10 @@ public enum Introspect {
         }
         
         for subview in superview.subviews[0..<entryIndex].reversed() {
+            if let typed = subview as? AnyViewType {
+                return typed
+            }
+
             if let typed = findChild(ofType: type, in: subview) {
                 return typed
             }
@@ -124,7 +128,7 @@ public enum Introspect {
         return nil
     }
     
-    /// Finds a next sibling that contains a view of the specified type.
+    /// Finds a next sibling that is or contains a view of the specified type.
     /// This method inspects siblings recursively.
     /// Returns nil if no sibling contains the specified type.
     public static func nextSibling<AnyViewType: PlatformView>(
@@ -139,6 +143,10 @@ public enum Introspect {
         }
         
         for subview in superview.subviews[entryIndex..<superview.subviews.endIndex] {
+            if let typed = subview as? AnyViewType {
+                return typed
+            }
+
             if let typed = findChild(ofType: type, in: subview) {
                 return typed
             }


### PR DESCRIPTION
Looks like in iOS 14 the sibling view is the UIScrollView, as opposed to a ViewHost containing a UIScrollView. Added a check to see if the sibling itself is a UIScrollView.

The iOS 14 SwiftUI ScrollView type is as follows:

`<SwiftUI.HostingScrollView: 0x7fd3ae835200; baseClass = UIScrollView; frame = (84.5 0; 151.5 568); anchorPoint = (0, 0); clipsToBounds = YES; gestureRecognizers = <NSArray: 0x600001de89f0>; layer = <CALayer: 0x60000134e060>; contentOffset: {0, -20}; contentSize: {151.5, 1746.5}; adjustedContentInset: {20, 0, 0, 0}>`

Tested using a simple example app:

![image](https://user-images.githubusercontent.com/60994492/94227942-b6625280-fec9-11ea-8728-b8b10b4bbeaf.png)

![image](https://user-images.githubusercontent.com/60994492/94227983-d6921180-fec9-11ea-93cf-f4e7c5fea891.png)
