### PR TITLE
[HOTFIX] Fixes introspectScrollView for iOS 14.2+

### DIFF
--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -77,7 +77,9 @@ extension View {
     
     /// Finds a `UIScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
     public func introspectScrollView(customize: @escaping (UIScrollView) -> ()) -> some View {
-        if #available(iOS 14.0, tvOS 14.0, macOS 11.0, *) {
+        if #available(iOS 14.2, *) {
+            return introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)
+        } else if #available(iOS 14.0, tvOS 14.0, macOS 11.0, *) {
             return introspect(selector: TargetViewSelector.ancestorOrSiblingOfType, customize: customize)
         } else {
             return introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)


### PR DESCRIPTION
`introspectScrollView` is not finding the scrollviews for iOS 14.2+ with the method `introspect(selector: TargetViewSelector.ancestorOrSiblingOfType, customize: customize)`, but `introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)` works perfectly.

Being that, I'm using the method mentioned above until a better solution is found.