### PR TITLE
Use Xcode 12.4.0 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 
 # Shared Xcode version between jobs
-xcode-version: &xcode-version "12.0.1"
+xcode-version: &xcode-version "12.4.0"
 
 # This is the key that we use to store and restore our dependencies cache.
 # It needs to be different anytime we add Pods, Gems, or npm packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## master
 
+- Update CircleCI config to use Xcode 12.4.0
+
 ## [0.1.2]
 
  - Allow iOS 11, tvOS 11, macOS 10.13 as deployment target with SPM.


### PR DESCRIPTION
We need to upgrade to Xcode 12.4.0 for macOS 11 SDK support.

This is needed in order to get #52 merged.