### PR TITLE
Add introspection for `NSTabView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## master
 
+- Added `.introspectTabView()` on macOS
+
 ## [0.1.3]
 
 - Added `introspectTableViewCell`

--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -193,5 +193,10 @@ extension View {
     public func introspectSegmentedControl(customize: @escaping (NSSegmentedControl) -> ()) -> some View {
         return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
+    
+    /// Finds a `NSTabView` from a `SwiftUI.TabView`
+    public func introspectTabView(customize: @escaping (NSTabView) -> ()) -> some View {
+        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+    }
 }
 #endif

--- a/IntrospectTests/AppKitTests.swift
+++ b/IntrospectTests/AppKitTests.swift
@@ -184,6 +184,26 @@ private struct SegmentedControlTestView: View {
 }
 
 @available(macOS 10.15.0, *)
+private struct TabViewTestView: View {
+    let spy: () -> Void
+    var body: some View {
+        TabView {
+            Text("Contents")
+                .tabItem {
+                    Text("Tab 1")
+                }
+            Text("Contents")
+                .tabItem {
+                    Text("Tab 2")
+                }
+        }
+        .introspectTabView { tabView in
+            self.spy()
+        }
+    }
+}
+
+@available(macOS 10.15.0, *)
 class AppKitTests: XCTestCase {
     
     func testList() {
@@ -311,6 +331,16 @@ class AppKitTests: XCTestCase {
         
         let expectation = XCTestExpectation()
         let view = SegmentedControlTestView(spy: {
+            expectation.fulfill()
+        })
+        TestUtils.present(view: view)
+        wait(for: [expectation], timeout: TestUtils.Constants.timeout)
+    }
+    
+    func testTabView() {
+        
+        let expectation = XCTestExpectation()
+        let view = TabViewTestView(spy: {
             expectation.fulfill()
         })
         TestUtils.present(view: view)


### PR DESCRIPTION
This adds a method to introspect a `SwiftUI.TabView` and retrieve the corresponding `NSTabView`.

It thereby fixes #32.