### PR TITLE
Fix Platform Versions

### DIFF
--- a/Introspect.podspec
+++ b/Introspect.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.source_files = 'Introspect/*.swift'
 
   spec.swift_version = '5.1'
-  spec.ios.deployment_target = '11.0'
-  spec.tvos.deployment_target = '11.0'
-  spec.osx.deployment_target = '10.13'
+  spec.ios.deployment_target = '13.0'
+  spec.tvos.deployment_target = '13.0'
+  spec.osx.deployment_target = '10.15'
 end

--- a/Introspect/AppKitIntrospectionView.swift
+++ b/Introspect/AppKitIntrospectionView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import AppKit
 
 /// Introspection NSView that is inserted alongside the target view.
-@available(macOS 10.15.0, *)
 public class IntrospectionNSView: NSView {
     
     required init() {
@@ -23,7 +22,6 @@ public class IntrospectionNSView: NSView {
 
 /// Introspection View that is injected into the UIKit hierarchy alongside the target view.
 /// After `updateNSView` is called, it calls `selector` to find the target view, then `customize` when the target view is found.
-@available(macOS 10.15.0, *)
 public struct AppKitIntrospectionView<TargetViewType: NSView>: NSViewRepresentable {
     
     /// Method that introspects the view hierarchy to find the target view.

--- a/Introspect/UIKitIntrospectionView.swift
+++ b/Introspect/UIKitIntrospectionView.swift
@@ -3,7 +3,6 @@ import UIKit
 import SwiftUI
 
 /// Introspection UIView that is inserted alongside the target view.
-@available(iOS 13.0, *)
 public class IntrospectionUIView: UIView {
     
     required init() {
@@ -20,7 +19,6 @@ public class IntrospectionUIView: UIView {
 
 /// Introspection View that is injected into the UIKit hierarchy alongside the target view.
 /// After `updateUIView` is called, it calls `selector` to find the target view, then `customize` when the target view is found.
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 public struct UIKitIntrospectionView<TargetViewType: UIView>: UIViewRepresentable {
     
     /// Method that introspects the view hierarchy to find the target view.

--- a/Introspect/UIKitIntrospectionViewController.swift
+++ b/Introspect/UIKitIntrospectionViewController.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import UIKit
 
 /// Introspection UIViewController that is inserted alongside the target view controller.
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 public class IntrospectionUIViewController: UIViewController {
     required init() {
         super.init(nibName: nil, bundle: nil)
@@ -17,7 +16,6 @@ public class IntrospectionUIViewController: UIViewController {
 }
 
 /// This is the same logic as IntrospectionView but for view controllers. Please see details above.
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 public struct UIKitIntrospectionViewController<TargetViewControllerType: UIViewController>: UIViewControllerRepresentable {
     
     let selector: (IntrospectionUIViewController) -> TargetViewControllerType?

--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -6,7 +6,6 @@ import AppKit
 import UIKit
 #endif
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 extension View {
     public func inject<SomeView>(_ view: SomeView) -> some View where SomeView: View {
         return overlay(view.frame(width: 0, height: 0))
@@ -14,7 +13,6 @@ extension View {
 }
 
 #if canImport(UIKit)
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 extension View {
     
     /// Finds a `TargetView` from a `SwiftUI.View`
@@ -131,7 +129,6 @@ extension View {
 #endif
 
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-@available(macOS 10.15.0, *)
 extension View {
     
     /// Finds a `TargetView` from a `SwiftUI.View`

--- a/IntrospectTests/AppKitTests.swift
+++ b/IntrospectTests/AppKitTests.swift
@@ -4,7 +4,6 @@ import XCTest
 import SwiftUI
 @testable import Introspect
 
-@available(macOS 10.15.0, *)
 enum TestUtils {
     enum Constants {
         static let timeout: TimeInterval = 5
@@ -24,7 +23,6 @@ enum TestUtils {
     }
 }
 
-@available(macOS 10.15.0, *)
 private struct ListTestView: View {
     
     let spy1: () -> Void
@@ -53,7 +51,6 @@ private struct ListTestView: View {
     }
 }
 
-@available(macOS 10.15.0, *)
 private struct ScrollTestView: View {
     
     let spy1: (NSScrollView) -> Void
@@ -78,7 +75,6 @@ private struct ScrollTestView: View {
     }
 }
 
-@available(macOS 10.15.0, *)
 private struct NestedScrollTestView: View {
 
     let spy1: (NSScrollView) -> Void
@@ -103,7 +99,6 @@ private struct NestedScrollTestView: View {
     }
 }
 
-@available(macOS 10.15.0, *)
 private struct TextFieldTestView: View {
     let spy: () -> Void
     @State private var textFieldValue = ""
@@ -127,7 +122,6 @@ private struct TextEditorTestView: View {
     }
 }
 
-@available(macOS 10.15.0, *)
 private struct SliderTestView: View {
     let spy: () -> Void
     @State private var sliderValue = 0.0
@@ -139,7 +133,6 @@ private struct SliderTestView: View {
     }
 }
 
-@available(macOS 10.15.0, *)
 private struct StepperTestView: View {
     let spy: () -> Void
     var body: some View {
@@ -152,7 +145,6 @@ private struct StepperTestView: View {
     }
 }
 
-@available(macOS 10.15.0, *)
 private struct DatePickerTestView: View {
     let spy: () -> Void
     @State private var datePickerValue = Date()
@@ -166,7 +158,6 @@ private struct DatePickerTestView: View {
     }
 }
 
-@available(macOS 10.15.0, *)
 private struct SegmentedControlTestView: View {
     @State private var pickerValue = 0
     let spy: () -> Void
@@ -183,7 +174,6 @@ private struct SegmentedControlTestView: View {
     }
 }
 
-@available(macOS 10.15.0, *)
 private struct TabViewTestView: View {
     let spy: () -> Void
     var body: some View {
@@ -203,7 +193,6 @@ private struct TabViewTestView: View {
     }
 }
 
-@available(macOS 10.15.0, *)
 private struct ButtonTestView: View {
     let spy: () -> Void
     var body: some View {
@@ -214,7 +203,6 @@ private struct ButtonTestView: View {
     }
 }
 
-@available(macOS 10.15.0, *)
 class AppKitTests: XCTestCase {
     
     func testList() {

--- a/IntrospectTests/UIKitTests.swift
+++ b/IntrospectTests/UIKitTests.swift
@@ -4,7 +4,6 @@ import SwiftUI
 
 @testable import Introspect
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 enum TestUtils {
     enum Constants {
         static let timeout: TimeInterval = 3
@@ -33,7 +32,6 @@ enum TestUtils {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct NavigationTestView: View {
     let spy: () -> Void
     var body: some View {
@@ -48,7 +46,6 @@ private struct NavigationTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct ViewControllerTestView: View {
     let spy: () -> Void
     var body: some View {
@@ -63,7 +60,6 @@ private struct ViewControllerTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct NavigationRootTestView: View {
     let spy: () -> Void
     var body: some View {
@@ -78,7 +74,6 @@ private struct NavigationRootTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct TabTestView: View {
     @State private var selection = 0
     let spy: () -> Void
@@ -93,7 +88,6 @@ private struct TabTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct TabRootTestView: View {
     @State private var selection = 0
     let spy: () -> Void
@@ -108,7 +102,6 @@ private struct TabRootTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct ListTestView: View {
     
     let spy1: () -> Void
@@ -137,7 +130,6 @@ private struct ListTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct ScrollTestView: View {
     
     let spy1: (UIScrollView) -> Void
@@ -161,7 +153,6 @@ private struct ScrollTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct NestedScrollTestView: View {
 
     let spy1: (UIScrollView) -> Void
@@ -186,7 +177,6 @@ private struct NestedScrollTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct TextFieldTestView: View {
     let spy1: (UITextField) -> Void
     let spy2: (UITextField) -> Void
@@ -230,7 +220,6 @@ private struct TextEditorTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 @available(tvOS, unavailable)
 private struct ToggleTestView: View {
     let spy: () -> Void
@@ -243,7 +232,6 @@ private struct ToggleTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 @available(tvOS, unavailable)
 private struct SliderTestView: View {
     let spy: () -> Void
@@ -256,7 +244,6 @@ private struct SliderTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 @available(tvOS, unavailable)
 private struct StepperTestView: View {
     let spy: () -> Void
@@ -270,7 +257,6 @@ private struct StepperTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 @available(tvOS, unavailable)
 private struct DatePickerTestView: View {
     let spy: () -> Void
@@ -285,7 +271,6 @@ private struct DatePickerTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct SegmentedControlTestView: View {
     @State private var pickerValue = 0
     let spy: () -> Void
@@ -302,7 +287,6 @@ private struct SegmentedControlTestView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 class UIKitTests: XCTestCase {
     func testNavigation() {
         

--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,9 @@ import PackageDescription
 let package = Package(
     name: "Introspect",
     platforms: [
-        .macOS(.v10_13),
-        .iOS(.v11),
-        .tvOS(.v11)
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13)
     ],
     products: [
         .library(


### PR DESCRIPTION
There are a lot of `@available(iOS 13, tvOS 13, macOS 11.15 *)` checks in the repo. As SwiftUI only exists on these platforms anyway, I would propose we remove them and move the platforms to these versions.

@ldiqual I would also like to have your take on whether there is a reason to keep it the way it was.