### PR TITLE
Add .introspectColorWell()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ## master
 
+- Added `.introspectColorWell()` on iOS and macOS
 - Added `.introspectButton()` on macOS
 - Fix UITextField with cornerRadius
 - Added `.introspectTabView()` on macOS

--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -127,6 +127,13 @@ extension View {
     public func introspectSegmentedControl(customize: @escaping (UISegmentedControl) -> ()) -> some View {
         return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
+    
+    /// Finds a `UIColorWell` from a `SwiftUI.ColorPicker`
+    @available(iOS 14.0, *)
+    @available(tvOS, unavailable)
+    public func introspectColorWell(customize: @escaping (UIColorWell) -> ()) -> some View {
+        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+    }
 }
 #endif
 
@@ -201,6 +208,12 @@ extension View {
     
     /// Finds a `NSButton` from a `SwiftUI.Button`
     public func introspectButton(customize: @escaping (NSButton) -> ()) -> some View {
+        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+    }
+    
+    /// Finds a `NSColorWell` from a `SwiftUI.ColorPicker`
+    @available(macOS 11.0, *)
+    public func introspectColorWell(customize: @escaping (NSColorWell) -> ()) -> some View {
         return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
 }

--- a/IntrospectTests/AppKitTests.swift
+++ b/IntrospectTests/AppKitTests.swift
@@ -214,6 +214,19 @@ private struct ButtonTestView: View {
     }
 }
 
+@available(macOS 11.0, *)
+private struct ColorWellTestView: View {
+    @State private var color = Color.black
+    let spy: () -> Void
+    
+    var body: some View {
+        ColorPicker("Picker", selection: $color)
+        .introspectColorWell { colorWell in
+            self.spy()
+        }
+    }
+}
+
 @available(macOS 10.15.0, *)
 class AppKitTests: XCTestCase {
     
@@ -362,6 +375,17 @@ class AppKitTests: XCTestCase {
         
         let expectation = XCTestExpectation()
         let view = ButtonTestView(spy: {
+            expectation.fulfill()
+        })
+        TestUtils.present(view: view)
+        wait(for: [expectation], timeout: TestUtils.Constants.timeout)
+    }
+    
+    @available(macOS 11.0, *)
+    func testColorPicker() {
+
+        let expectation = XCTestExpectation()
+        let view = ColorWellTestView(spy: {
             expectation.fulfill()
         })
         TestUtils.present(view: view)

--- a/IntrospectTests/AppKitTests.swift
+++ b/IntrospectTests/AppKitTests.swift
@@ -381,15 +381,16 @@ class AppKitTests: XCTestCase {
         wait(for: [expectation], timeout: TestUtils.Constants.timeout)
     }
     
-    @available(macOS 11.0, *)
     func testColorPicker() {
 
-        let expectation = XCTestExpectation()
-        let view = ColorWellTestView(spy: {
-            expectation.fulfill()
-        })
-        TestUtils.present(view: view)
-        wait(for: [expectation], timeout: TestUtils.Constants.timeout)
+        if #available(macOS 11.0, *) {
+            let expectation = XCTestExpectation()
+            let view = ColorWellTestView(spy: {
+                expectation.fulfill()
+            })
+            TestUtils.present(view: view)
+            wait(for: [expectation], timeout: TestUtils.Constants.timeout)
+        }
     }
 }
 #endif

--- a/IntrospectTests/UIKitTests.swift
+++ b/IntrospectTests/UIKitTests.swift
@@ -217,7 +217,7 @@ private struct TextFieldTestView: View {
     }
 }
 
-@available(iOS 14.0, macCatalyst 14.0, macOS 11.0, *)
+@available(iOS 14.0, macCatalyst 14.0, macOS 11.0, tvOS 13.0, *)
 @available(tvOS, unavailable, message: "TextEditor is not available in tvOS.")
 private struct TextEditorTestView: View {
     let spy: () -> Void
@@ -297,6 +297,20 @@ private struct SegmentedControlTestView: View {
         }
         .pickerStyle(SegmentedPickerStyle())
         .introspectSegmentedControl { segmentedControl in
+            self.spy()
+        }
+    }
+}
+
+@available(iOS 14.0, tvOS 13.0, macOS 11.0, *)
+@available(tvOS, unavailable)
+private struct ColorWellTestView: View {
+    @State private var color = Color.black
+    let spy: () -> Void
+    
+    var body: some View {
+        ColorPicker("Picker", selection: $color)
+        .introspectColorWell { colorWell in
             self.spy()
         }
     }
@@ -512,12 +526,24 @@ class UIKitTests: XCTestCase {
         wait(for: [expectation], timeout: TestUtils.Constants.timeout)
     }
     
-    @available(iOS 14.0, macCatalyst 14.0, macOS 15.0, *)
+    @available(iOS 14.0, macCatalyst 14.0, macOS 11.0, *)
     @available(tvOS, unavailable, message: "TextEditor is not available in tvOS.")
     func testTextEditor() {
 
         let expectation = XCTestExpectation()
         let view = TextEditorTestView(spy: {
+            expectation.fulfill()
+        })
+        TestUtils.present(view: view)
+        wait(for: [expectation], timeout: TestUtils.Constants.timeout)
+    }
+    
+    @available(iOS 14.0, macCatalyst 14.0, macOS 11.0, *)
+    @available(tvOS, unavailable, message: "ColorPicker is not available in tvOS.")
+    func testColorPicker() {
+
+        let expectation = XCTestExpectation()
+        let view = ColorWellTestView(spy: {
             expectation.fulfill()
         })
         TestUtils.present(view: view)


### PR DESCRIPTION
This PR adds color well introspection to iOS and macOS, thereby resolving #59.