### PR TITLE
Add iPad to Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,6 +11,14 @@ platform :ios do
             try_count: 3,
             quit_simulators: false
         )
+        
+        multi_scan(
+            devices: ["iPad (8th generation)"],
+            scheme: "Introspect iOS",
+            skip_build: options[:ci] == 'github',
+            try_count: 3,
+            quit_simulators: false
+        )
 
         multi_scan(
             devices: ["Apple TV"],


### PR DESCRIPTION
This PR adds an iPad scan to the Fastfile and fixes the tests currently failing on iPad.