### PR TITLE
Add .introspectSplitViewController() on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ## master
 
+- Added `.introspectSplitViewController()` on iOS
 - Added `.introspectColorWell()` on iOS and macOS
 - Added `.introspectButton()` on macOS
 - Fix UITextField with cornerRadius

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -48,7 +48,7 @@ public enum Introspect {
                 return typed
             }
         }
-        return nil
+        return root as? AnyViewControllerType
     }
     
     /// Finds a subview of the specified type.

--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -45,6 +45,23 @@ extension View {
         ))
     }
     
+    /// Finds a `UISplitViewController` from  a `SwiftUI.NavigationView` with style `DoubleColumnNavigationViewStyle`.
+    public func introspectSplitViewController(customize: @escaping (UISplitViewController) -> ()) -> some View {
+            return inject(UIKitIntrospectionViewController(
+                selector: { introspectionViewController in
+                    
+                    // Search in ancestors
+                    if let splitViewController = introspectionViewController.splitViewController {
+                        return splitViewController
+                    }
+                    
+                    // Search in siblings
+                    return Introspect.previousSibling(containing: UISplitViewController.self, from: introspectionViewController)
+                },
+                customize: customize
+            ))
+        }
+    
     /// Finds the containing `UIViewController` of a SwiftUI view.
     public func introspectViewController(customize: @escaping (UIViewController) -> ()) -> some View {
         return inject(UIKitIntrospectionViewController(

--- a/IntrospectTests/UIKitTests.swift
+++ b/IntrospectTests/UIKitTests.swift
@@ -50,6 +50,22 @@ private struct NavigationTestView: View {
 }
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
+private struct SplitNavigationTestView: View {
+    let spy: () -> Void
+    var body: some View {
+        NavigationView {
+            VStack {
+                EmptyView()
+            }
+        }
+        .navigationViewStyle(DoubleColumnNavigationViewStyle())
+        .introspectSplitViewController { navigationController in
+            self.spy()
+        }
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 private struct ViewControllerTestView: View {
     let spy: () -> Void
     var body: some View {
@@ -324,6 +340,16 @@ class UIKitTests: XCTestCase {
         
         let expectation = XCTestExpectation()
         let view = NavigationTestView(spy: {
+            expectation.fulfill()
+        })
+        TestUtils.present(view: view)
+        wait(for: [expectation], timeout: TestUtils.Constants.timeout)
+    }
+    
+    func testSplitNavigation() {
+        
+        let expectation = XCTestExpectation()
+        let view = SplitNavigationTestView(spy: {
             expectation.fulfill()
         })
         TestUtils.present(view: view)

--- a/IntrospectTests/UIKitTests.swift
+++ b/IntrospectTests/UIKitTests.swift
@@ -345,16 +345,6 @@ class UIKitTests: XCTestCase {
         wait(for: [expectation], timeout: TestUtils.Constants.timeout)
     }
     
-    func testSplitNavigation() {
-        
-        let expectation = XCTestExpectation()
-        let view = SplitNavigationTestView(spy: {
-            expectation.fulfill()
-        })
-        TestUtils.present(view: view)
-        wait(for: [expectation], timeout: TestUtils.Constants.timeout)
-    }
-    
     func testViewController() {
         
         let expectation = XCTestExpectation()
@@ -503,6 +493,16 @@ class UIKitTests: XCTestCase {
     }
     
     #if os(iOS)
+    func testSplitNavigation() {
+        
+        let expectation = XCTestExpectation()
+        let view = SplitNavigationTestView(spy: {
+            expectation.fulfill()
+        })
+        TestUtils.present(view: view)
+        wait(for: [expectation], timeout: TestUtils.Constants.timeout)
+    }
+    
     func testRootNavigation() {
         
         let expectation = XCTestExpectation()

--- a/IntrospectTests/UIKitTests.swift
+++ b/IntrospectTests/UIKitTests.swift
@@ -45,6 +45,7 @@ private struct NavigationTestView: View {
                 self.spy()
             }
         }
+        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 
@@ -56,9 +57,10 @@ private struct ViewControllerTestView: View {
             VStack {
                 EmptyView()
             }
-            .introspectViewController { viewController in
-                self.spy()
-            }
+        }
+        .introspectViewController { viewController in
+            print("oil:", viewController)
+            self.spy()
         }
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,6 +11,14 @@ platform :ios do
             try_count: 3,
             quit_simulators: false
         )
+        
+        multi_scan(
+            devices: ["iPad (8th generation)"],
+            scheme: "Introspect iOS",
+            skip_build: options[:ci] == 'github',
+            try_count: 3,
+            quit_simulators: false
+        )
 
         multi_scan(
             devices: ["Apple TV"],


### PR DESCRIPTION
This adds introspection of the UISplitViewController on iOS and thereby fixes #70.