### PR TITLE
Remove explicit returns to simplify code

### DIFF
--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -9,7 +9,7 @@ import UIKit
 @available(iOS 13.0, tvOS 13.0, macOS 10.15.0, *)
 extension View {
     public func inject<SomeView>(_ view: SomeView) -> some View where SomeView: View {
-        return overlay(view.frame(width: 0, height: 0))
+        overlay(view.frame(width: 0, height: 0))
     }
 }
 
@@ -22,7 +22,7 @@ extension View {
         selector: @escaping (IntrospectionUIView) -> TargetView?,
         customize: @escaping (TargetView) -> ()
     ) -> some View {
-        return inject(UIKitIntrospectionView(
+        inject(UIKitIntrospectionView(
             selector: selector,
             customize: customize
         ))
@@ -30,7 +30,7 @@ extension View {
     
     /// Finds a `UINavigationController` from any view embedded in a `SwiftUI.NavigationView`.
     public func introspectNavigationController(customize: @escaping (UINavigationController) -> ()) -> some View {
-        return inject(UIKitIntrospectionViewController(
+        inject(UIKitIntrospectionViewController(
             selector: { introspectionViewController in
                 
                 // Search in ancestors
@@ -47,7 +47,7 @@ extension View {
     
     /// Finds a `UISplitViewController` from  a `SwiftUI.NavigationView` with style `DoubleColumnNavigationViewStyle`.
     public func introspectSplitViewController(customize: @escaping (UISplitViewController) -> ()) -> some View {
-            return inject(UIKitIntrospectionViewController(
+            inject(UIKitIntrospectionViewController(
                 selector: { introspectionViewController in
                     
                     // Search in ancestors
@@ -64,7 +64,7 @@ extension View {
     
     /// Finds the containing `UIViewController` of a SwiftUI view.
     public func introspectViewController(customize: @escaping (UIViewController) -> ()) -> some View {
-        return inject(UIKitIntrospectionViewController(
+        inject(UIKitIntrospectionViewController(
             selector: { $0.parent },
             customize: customize
         ))
@@ -72,7 +72,7 @@ extension View {
 
     /// Finds a `UITabBarController` from any SwiftUI view embedded in a `SwiftUI.TabView`
     public func introspectTabBarController(customize: @escaping (UITabBarController) -> ()) -> some View {
-        return inject(UIKitIntrospectionViewController(
+        inject(UIKitIntrospectionViewController(
             selector: { introspectionViewController in
                 
                 // Search in ancestors
@@ -89,12 +89,12 @@ extension View {
     
     /// Finds a `UITableView` from a `SwiftUI.List`, or `SwiftUI.List` child.
     public func introspectTableView(customize: @escaping (UITableView) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)
     }
     
     /// Finds a `UITableViewCell` from a `SwiftUI.List`, or `SwiftUI.List` child. You can attach this directly to the element inside the list.
     public func introspectTableViewCell(customize: @escaping (UITableViewCell) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)
     }
 
     /// Finds a `UIScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
@@ -108,48 +108,48 @@ extension View {
     
     /// Finds a `UITextField` from a `SwiftUI.TextField`
     public func introspectTextField(customize: @escaping (UITextField) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContainingOrAncestorOrAncestorChild, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContainingOrAncestorOrAncestorChild, customize: customize)
     }
 
     /// Finds a `UITextView` from a `SwiftUI.TextEditor`
     public func introspectTextView(customize: @escaping (UITextView) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `UISwitch` from a `SwiftUI.Toggle`
     @available(tvOS, unavailable)
     public func introspectSwitch(customize: @escaping (UISwitch) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `UISlider` from a `SwiftUI.Slider`
     @available(tvOS, unavailable)
     public func introspectSlider(customize: @escaping (UISlider) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `UIStepper` from a `SwiftUI.Stepper`
     @available(tvOS, unavailable)
     public func introspectStepper(customize: @escaping (UIStepper) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `UIDatePicker` from a `SwiftUI.DatePicker`
     @available(tvOS, unavailable)
     public func introspectDatePicker(customize: @escaping (UIDatePicker) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `UISegmentedControl` from a `SwiftUI.Picker` with style `SegmentedPickerStyle`
     public func introspectSegmentedControl(customize: @escaping (UISegmentedControl) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `UIColorWell` from a `SwiftUI.ColorPicker`
     @available(iOS 14.0, *)
     @available(tvOS, unavailable)
     public func introspectColorWell(customize: @escaping (UIColorWell) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
 }
 #endif
@@ -163,7 +163,7 @@ extension View {
         selector: @escaping (IntrospectionNSView) -> TargetView?,
         customize: @escaping (TargetView) -> ()
     ) -> some View {
-        return inject(AppKitIntrospectionView(
+        inject(AppKitIntrospectionView(
             selector: selector,
             customize: customize
         ))
@@ -171,12 +171,12 @@ extension View {
     
     /// Finds a `NSTableView` from a `SwiftUI.List`, or `SwiftUI.List` child.
     public func introspectTableView(customize: @escaping (NSTableView) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)
     }
 
     /// Finds a `NSTableCellView` from a `SwiftUI.List`, or `SwiftUI.List` child. You can attach this directly to the element inside the list.
     public func introspectTableViewCell(customize: @escaping (NSTableCellView) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: customize)
     }
 
     /// Finds a `NSScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
@@ -190,48 +190,48 @@ extension View {
     
     /// Finds a `NSTextField` from a `SwiftUI.TextField`
     public func introspectTextField(customize: @escaping (NSTextField) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `NSTextView` from a `SwiftUI.TextView`
     public func introspectTextView(customize: @escaping (NSTextView) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `NSSlider` from a `SwiftUI.Slider`
     public func introspectSlider(customize: @escaping (NSSlider) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `NSStepper` from a `SwiftUI.Stepper`
     public func introspectStepper(customize: @escaping (NSStepper) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `NSDatePicker` from a `SwiftUI.DatePicker`
     public func introspectDatePicker(customize: @escaping (NSDatePicker) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `NSSegmentedControl` from a `SwiftUI.Picker` with style `SegmentedPickerStyle`
     public func introspectSegmentedControl(customize: @escaping (NSSegmentedControl) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `NSTabView` from a `SwiftUI.TabView`
     public func introspectTabView(customize: @escaping (NSTabView) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `NSButton` from a `SwiftUI.Button`
     public func introspectButton(customize: @escaping (NSButton) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
     
     /// Finds a `NSColorWell` from a `SwiftUI.ColorPicker`
     @available(macOS 11.0, *)
     public func introspectColorWell(customize: @escaping (NSColorWell) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
+        introspect(selector: TargetViewSelector.siblingContaining, customize: customize)
     }
 }
 #endif


### PR DESCRIPTION
Since Swift 5.1, [SE-0255](https://github.com/apple/swift-evolution/blob/master/proposals/0255-omit-return.md) evolved Swift to have the capability to implicitly return from functions.

I removed unnecessary explicit returns to improve code readability and simplicity.