### PR TITLE
fix: update Cocoapods install statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ https://github.com/siteline/SwiftUI-Introspect.git
 ### Cocoapods
 
 ```
-pod "Introspect"
+pod 'Introspect'
 ```
 
 Introspection


### PR DESCRIPTION
[Cocoapods](https://guides.cocoapods.org/syntax/podfile.html) syntax follows the syntax to use single quotes to add Pods to a Podfile. Though it is implicit, many users will copy the method provided in the readme and face issues due to the double quotes used.

Hence the only change in this pull request is changing`pod "Introspect"` to  `pod 'Introspect'`.

