### PR TITLE
Fix `introspectPagedTabView` on iOS 16

### DIFF
--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -131,14 +131,20 @@ extension View {
     /// Customize is called with a `UICollectionView` wrapper, and the horizontal `UIScrollView`.
     @available(iOS 14, tvOS 14, *)
     public func introspectPagedTabView(customize: @escaping (UICollectionView, UIScrollView) -> ()) -> some View {
-        return introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: { (collectionView: UICollectionView) in
-            for subview in collectionView.subviews {
-                if NSStringFromClass(type(of: subview)).contains("EmbeddedScrollView"), let scrollView = subview as? UIScrollView {
-                    customize(collectionView, scrollView)
-                    break
+        if #available(iOS 16, *) {
+            return introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: { (collectionView: UICollectionView) in
+                customize(collectionView, collectionView)
+            })
+        } else {
+            return introspect(selector: TargetViewSelector.ancestorOrSiblingContaining, customize: { (collectionView: UICollectionView) in
+                for subview in collectionView.subviews {
+                    if NSStringFromClass(type(of: subview)).contains("EmbeddedScrollView"), let scrollView = subview as? UIScrollView {
+                        customize(collectionView, scrollView)
+                        break
+                    }
                 }
-            }
-        })
+            })
+        }
     }
 
     /// Finds a `UITextField` from a `SwiftUI.TextField`

--- a/IntrospectTests/UIKitTests.swift
+++ b/IntrospectTests/UIKitTests.swift
@@ -124,25 +124,14 @@ private struct PageTabViewStyleTestView: View {
     let spy: (UICollectionView, UIScrollView) -> Void
 
     var body: some View {
-        if #available(iOS 16, tvOS 16, *) {
-            TabView {
-                Text("Item 1")
-                    .tag(0)
-            }
-            .tabViewStyle(PageTabViewStyle())
-            .introspectCollectionView { collectionView in
-                spy(collectionView, collectionView)
-            }
-        } else {
-            TabView {
-                Text("Item 1")
-                    .tag(0)
-            }
-            .tabViewStyle(PageTabViewStyle())
-            .introspectPagedTabView { collectionView, scrollView in
-                spy(collectionView, scrollView)
-            }
-        }
+      TabView {
+          Text("Item 1")
+              .tag(0)
+      }
+      .tabViewStyle(PageTabViewStyle())
+      .introspectPagedTabView { collectionView, scrollView in
+          spy(collectionView, scrollView)
+      }
     }
 }
 

--- a/IntrospectTests/UIKitTests.swift
+++ b/IntrospectTests/UIKitTests.swift
@@ -124,14 +124,14 @@ private struct PageTabViewStyleTestView: View {
     let spy: (UICollectionView, UIScrollView) -> Void
 
     var body: some View {
-      TabView {
-          Text("Item 1")
-              .tag(0)
-      }
-      .tabViewStyle(PageTabViewStyle())
-      .introspectPagedTabView { collectionView, scrollView in
-          spy(collectionView, scrollView)
-      }
+        TabView {
+            Text("Item 1")
+                .tag(0)
+        }
+        .tabViewStyle(PageTabViewStyle())
+        .introspectPagedTabView { collectionView, scrollView in
+            spy(collectionView, scrollView)
+        }
     }
 }
 


### PR DESCRIPTION
The paged Tab View should be handled differently on iOS 16, today we must handle this on the call site, wrapping our views in a `if #available(iOS 16, *)` .

I suggest we handle this directly in the library, on the `introspectPagedTabView` method.