### PR TITLE
Bump minimum Swift version to 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## master
 
+- Infrastructure: symlink older SDKs to use in newer Xcode versions (#208)
+
 ## [0.2.3]
 
 - Fixed: `introspectPagedTabView` on iOS 16 (#200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ## master
 
+- Changed: minimum language version required is now Swift 5.5 (#209)
 - Infrastructure: symlink older SDKs to use in newer Xcode versions (#208)
 
 ## [0.2.3]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 
 import PackageDescription
 


### PR DESCRIPTION
This unlocks some newer language features required for the upcoming new API in #207.

Thankfully there aren't many more sizeable benefits for this library in Swift 5.6 onwards, so we'll easily be able to support Swift 5.5 for quite along time as part of the 1.0 semver contract.