### PR TITLE
Fix finding UIScrollViews that are clipped(), masked or combined with clipShape() or cornerRadius()

### DIFF
--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -319,7 +319,7 @@ public enum TargetViewSelector {
         return Introspect.findAncestor(ofType: TargetView.self, from: entry)
     }
     
-    public static func siblingOrAncestorOrSiblingContainingOrAncestorOrAncestorChild<TargetView: PlatformView>(from entry: PlatformView) -> TargetView? {
+    public static func siblingOrAncestorOrSiblingContainingOrAncestorChild<TargetView: PlatformView>(from entry: PlatformView) -> TargetView? {
         if let sibling: TargetView = siblingOfType(from: entry) {
             return sibling
         }

--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -318,6 +318,16 @@ public enum TargetViewSelector {
         }
         return Introspect.findAncestor(ofType: TargetView.self, from: entry)
     }
+    
+    public static func siblingOrAncestorOrSiblingContainingOrAncestorOrAncestorChild<TargetView: PlatformView>(from entry: PlatformView) -> TargetView? {
+        if let sibling: TargetView = siblingOfType(from: entry) {
+            return sibling
+        }
+        if let ancestor: TargetView = Introspect.findAncestor(ofType: TargetView.self, from: entry) {
+            return ancestor
+        }
+        return siblingContainingOrAncestorOrAncestorChild(from: entry)
+    }
 
     public static func ancestorOrSiblingContaining<TargetView: PlatformView>(from entry: PlatformView) -> TargetView? {
         if let tableView = Introspect.findAncestor(ofType: TargetView.self, from: entry) {

--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -120,7 +120,7 @@ extension View {
     /// Finds a `UIScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
     public func introspectScrollView(customize: @escaping (UIScrollView) -> ()) -> some View {
         if #available(iOS 14, tvOS 14, *) {
-            return introspect(selector: TargetViewSelector.siblingOrAncestorOrSiblingContainingOrAncestorOrAncestorChild, customize: customize)
+            return introspect(selector: TargetViewSelector.siblingOrAncestorOrSiblingContainingOrAncestorChild, customize: customize)
         } else {
             return introspect(selector: TargetViewSelector.siblingContainingOrAncestor, customize: customize)
         }
@@ -227,7 +227,7 @@ extension View {
     /// Finds a `NSScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
     public func introspectScrollView(customize: @escaping (NSScrollView) -> ()) -> some View {
         if #available(macOS 11, *) {
-            return introspect(selector: TargetViewSelector.siblingOrAncestorOrSiblingContainingOrAncestorOrAncestorChild, customize: customize)
+            return introspect(selector: TargetViewSelector.siblingOrAncestorOrSiblingContainingOrAncestorChild, customize: customize)
         } else {
             return introspect(selector: TargetViewSelector.siblingContainingOrAncestor, customize: customize)
         }

--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -120,7 +120,7 @@ extension View {
     /// Finds a `UIScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
     public func introspectScrollView(customize: @escaping (UIScrollView) -> ()) -> some View {
         if #available(iOS 14, tvOS 14, *) {
-            return introspect(selector: TargetViewSelector.siblingContainingOrAncestorOrAncestorChild, customize: customize)
+            return introspect(selector: TargetViewSelector.siblingOrAncestorOrSiblingContainingOrAncestorOrAncestorChild, customize: customize)
         } else {
             return introspect(selector: TargetViewSelector.siblingContainingOrAncestor, customize: customize)
         }
@@ -227,7 +227,7 @@ extension View {
     /// Finds a `NSScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
     public func introspectScrollView(customize: @escaping (NSScrollView) -> ()) -> some View {
         if #available(macOS 11, *) {
-            return introspect(selector: TargetViewSelector.siblingOfTypeOrAncestor, customize: customize)
+            return introspect(selector: TargetViewSelector.siblingOrAncestorOrSiblingContainingOrAncestorOrAncestorChild, customize: customize)
         } else {
             return introspect(selector: TargetViewSelector.siblingContainingOrAncestor, customize: customize)
         }

--- a/Introspect/ViewExtensions.swift
+++ b/Introspect/ViewExtensions.swift
@@ -120,7 +120,7 @@ extension View {
     /// Finds a `UIScrollView` from a `SwiftUI.ScrollView`, or `SwiftUI.ScrollView` child.
     public func introspectScrollView(customize: @escaping (UIScrollView) -> ()) -> some View {
         if #available(iOS 14, tvOS 14, *) {
-            return introspect(selector: TargetViewSelector.siblingOfTypeOrAncestor, customize: customize)
+            return introspect(selector: TargetViewSelector.siblingContainingOrAncestorOrAncestorChild, customize: customize)
         } else {
             return introspect(selector: TargetViewSelector.siblingContainingOrAncestor, customize: customize)
         }

--- a/IntrospectTests/AppKitTests.swift
+++ b/IntrospectTests/AppKitTests.swift
@@ -113,6 +113,31 @@ private struct NestedScrollTestView: View {
     }
 }
 
+private struct MaskedScrollTestView: View {
+    
+    let spy1: (NSScrollView) -> Void
+    let spy2: (NSScrollView) -> Void
+    
+    var body: some View {
+        HStack {
+            ScrollView {
+                Text("Item 1")
+            }
+            .introspectScrollView { scrollView in
+                self.spy1(scrollView)
+            }
+            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: 20.0))
+            ScrollView {
+                Text("Item 1")
+                .introspectScrollView { scrollView in
+                    self.spy2(scrollView)
+                }
+            }
+        }
+    }
+}
+
 private struct TextFieldTestView: View {
     let spy: () -> Void
     @State private var textFieldValue = ""
@@ -314,7 +339,6 @@ class AppKitTests: XCTestCase {
     }
 
     func testNestedScrollView() throws {
-
         let expectation1 = XCTestExpectation()
         let expectation2 = XCTestExpectation()
 
@@ -331,6 +355,33 @@ class AppKitTests: XCTestCase {
                 expectation2.fulfill()
             }
         )
+        TestUtils.present(view: view)
+        wait(for: [expectation1, expectation2], timeout: TestUtils.Constants.timeout)
+
+        let unwrappedScrollView1 = try XCTUnwrap(scrollView1)
+        let unwrappedScrollView2 = try XCTUnwrap(scrollView2)
+
+        XCTAssertNotEqual(unwrappedScrollView1, unwrappedScrollView2)
+    }
+    
+    func testMaskedScrollView() throws {
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+
+        var scrollView1: NSScrollView?
+        var scrollView2: NSScrollView?
+
+        let view = MaskedScrollTestView(
+            spy1: { scrollView in
+                scrollView1 = scrollView
+                expectation1.fulfill()
+            },
+            spy2: { scrollView in
+                scrollView2 = scrollView
+                expectation2.fulfill()
+            }
+        )
+        
         TestUtils.present(view: view)
         wait(for: [expectation1, expectation2], timeout: TestUtils.Constants.timeout)
 

--- a/IntrospectTests/AppKitTests.swift
+++ b/IntrospectTests/AppKitTests.swift
@@ -128,6 +128,7 @@ private struct MaskedScrollTestView: View {
             }
             .clipped()
             .clipShape(RoundedRectangle(cornerRadius: 20.0))
+            .cornerRadius(2.0)
             ScrollView {
                 Text("Item 1")
                 .introspectScrollView { scrollView in

--- a/IntrospectTests/UIKitTests.swift
+++ b/IntrospectTests/UIKitTests.swift
@@ -246,6 +246,7 @@ private struct MaskedScrollTestView: View {
             }
             .clipped()
             .clipShape(RoundedRectangle(cornerRadius: 20.0))
+            .cornerRadius(2.0)
             ScrollView {
                 Text("Item 1")
                 .introspectScrollView { scrollView in

--- a/IntrospectTests/UIKitTests.swift
+++ b/IntrospectTests/UIKitTests.swift
@@ -183,6 +183,7 @@ private struct ListTestView: View {
     }
 }
 
+
 private struct ScrollTestView: View {
     
     let spy1: (UIScrollView) -> Void
@@ -225,6 +226,31 @@ private struct NestedScrollTestView: View {
             }
             .introspectScrollView { scrollView in
                 self.spy1(scrollView)
+            }
+        }
+    }
+}
+
+private struct MaskedScrollTestView: View {
+    
+    let spy1: (UIScrollView) -> Void
+    let spy2: (UIScrollView) -> Void
+    
+    var body: some View {
+        HStack {
+            ScrollView {
+                Text("Item 1")
+            }
+            .introspectScrollView { scrollView in
+                self.spy1(scrollView)
+            }
+            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: 20.0))
+            ScrollView {
+                Text("Item 1")
+                .introspectScrollView { scrollView in
+                    self.spy2(scrollView)
+                }
             }
         }
     }
@@ -474,6 +500,34 @@ class UIKitTests: XCTestCase {
                 expectation2.fulfill()
             }
         )
+        TestUtils.present(view: view)
+        wait(for: [expectation1, expectation2], timeout: TestUtils.Constants.timeout)
+
+        let unwrappedScrollView1 = try XCTUnwrap(scrollView1)
+        let unwrappedScrollView2 = try XCTUnwrap(scrollView2)
+
+        XCTAssertNotEqual(unwrappedScrollView1, unwrappedScrollView2)
+    }
+    
+    func testMaskedScrollView() throws {
+        
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+
+        var scrollView1: UIScrollView?
+        var scrollView2: UIScrollView?
+
+        let view = MaskedScrollTestView(
+            spy1: { scrollView in
+                scrollView1 = scrollView
+                expectation1.fulfill()
+            },
+            spy2: { scrollView in
+                scrollView2 = scrollView
+                expectation2.fulfill()
+            }
+        )
+        
         TestUtils.present(view: view)
         wait(for: [expectation1, expectation2], timeout: TestUtils.Constants.timeout)
 


### PR DESCRIPTION
This should fix issue:
[issues 162](https://github.com/siteline/SwiftUI-Introspect/issues/162)

Fixes:
```swift
struct ContentView: View {
    var body: some View {
        HStack {
            ScrollViewReader { proxy in
                ScrollView(.horizontal) {
                    TimeLineView()
                }
                .introspectScrollView { scrollView in
                    print(scrollView)    //closure not called when clipped or masked
                }
                .clipped()              // this caused issues
                .mask(Text("Hello"))    // or this
                .clipShape(Rectangle()) // and this
            }
        }
    }
}
```
