### PR TITLE
Update README to include UICollectionView introspection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ NavigationView (DoubleColumnNavigationViewStyle) | UISplitViewController | _N/A_
 NavigationView (DoubleColumnNavigationViewStyle) | _N/A_ | NSSplitView | `.introspectSplitView()`
 _Any embedded view_ | UIViewController | _N/A_ | `.introspectViewController()`
 ScrollView | UIScrollView | NSScrollView | `.introspectScrollView()`
-List | UITableView | NSTableView | `.introspectTableView()`
-View in List | UITableViewCell | NSTableCellView | `introspectTableViewCell()`
+List (iOS15 and below) | UITableView | NSTableView | `.introspectTableView()`
+View in List (iOS15 and below) | UITableViewCell | NSTableCellView | `introspectTableViewCell()`
+List (iOS 16) | UICollectionView | _N/A_ | `.introspectCollectionView()`
+View in List (iOS 16) | UICollectionViewCell | _N/A_ | `.introspectCollectionViewCell()`
 TabView | UITabBarController | NSTabView | `.introspectTabBarController()` (iOS) <br/> `.introspectTabView()` (macOS)
 TextField | UITextField | NSTextField | `.introspectTextField()`
 Toggle | UISwitch | NSButton | `.introspectSwitch()` (iOS) <br/> `.introspectButton()` (macOS)


### PR DESCRIPTION
This PR updates the README to include the newly added `introspectCollectionView()` and `introspectCollectionViewCell()` functions from PR #169. It also clarifies that these new functions are available for Lists on iOS 16 and above, while the `introspectTableView()` and `introspectTableViewCell()` functions are available for iOS 15 and below.

```
- Added `introspectCollectionView()` and `introspectCollectionViewCell()` functions to the README
- Clarified that the new functions are available for Lists on iOS 16 and above
- Specified that `introspectTableView()` and `introspectTableViewCell()` are available for iOS 15 and below
```

Please let me know if any changes or additional information are required. Thank you!