### PR TITLE
Add advanced range-based platform version predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## master
 
+- Added: advanced range-based platform version predicates (#285)
+- Documentation: generate docs for extensions (#282)
+- Infrastructure: set up `tea` for CI and local environments (#276)
+
 ## [0.7.0]
 
 ### SwiftUIIntrospect

--- a/Sources/Introspect.swift
+++ b/Sources/Introspect.swift
@@ -41,21 +41,11 @@ extension View {
     /// ```
     public func introspect<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity>(
         _ viewType: SwiftUIViewType,
-        on platforms: (PlatformViewVersionGroup<SwiftUIViewType, PlatformSpecificEntity>)...,
+        on platforms: (PlatformViewVersionPredicate<SwiftUIViewType, PlatformSpecificEntity>)...,
         scope: IntrospectionScope? = nil,
         customize: @escaping (PlatformSpecificEntity) -> Void
     ) -> some View {
-        self.modifier(IntrospectModifier(viewType, on: platforms, scope: scope, customize: customize))
-    }
-
-    @_spi(Advanced)
-    public func introspect<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity>(
-        _ viewType: SwiftUIViewType,
-        onOrAfter platforms: (PlatformViewVersionSingle<SwiftUIViewType, PlatformSpecificEntity>)...,
-        scope: IntrospectionScope? = nil,
-        customize: @escaping (PlatformSpecificEntity) -> Void
-    ) -> some View {
-        self.modifier(IntrospectModifier(viewType, onOrAfter: platforms, scope: scope, customize: customize))
+        self.modifier(IntrospectModifier(viewType, platforms: platforms, scope: scope, customize: customize))
     }
 }
 
@@ -67,27 +57,12 @@ struct IntrospectModifier<SwiftUIViewType: IntrospectableViewType, PlatformSpeci
 
     init(
         _ viewType: SwiftUIViewType,
-        on platforms: [PlatformViewVersionGroup<SwiftUIViewType, PlatformSpecificEntity>],
+        platforms: [PlatformViewVersionPredicate<SwiftUIViewType, PlatformSpecificEntity>],
         scope: IntrospectionScope?,
         customize: @escaping (PlatformSpecificEntity) -> Void
     ) {
         self.scope = scope ?? viewType.scope
-        if let platform = platforms.first(where: \.containsCurrent) {
-            self.selector = platform.selector ?? .default
-        } else {
-            self.selector = nil
-        }
-        self.customize = customize
-    }
-
-    init(
-        _ viewType: SwiftUIViewType,
-        onOrAfter platforms: [PlatformViewVersionSingle<SwiftUIViewType, PlatformSpecificEntity>],
-        scope: IntrospectionScope?,
-        customize: @escaping (PlatformSpecificEntity) -> Void
-    ) {
-        self.scope = scope ?? viewType.scope
-        if let platform = platforms.first(where: \.isCurrentOrPast) {
+        if let platform = platforms.first(where: \.matches) {
             self.selector = platform.selector ?? .default
         } else {
             self.selector = nil

--- a/Sources/Introspect.swift
+++ b/Sources/Introspect.swift
@@ -21,8 +21,8 @@ extension View {
     ///
     /// - Parameters:
     ///   - viewType: The type of view to be introspected.
-    ///   - platforms: A list of `PlatformViewVersions` that specify platform-specific entities associated with the view, with one or more corresponding version numbers.
-    ///   - scope: An optional `IntrospectionScope` that specifies the scope of introspection.
+    ///   - platforms: A list of version predicates that specify platform-specific entities associated with the view.
+    ///   - scope: Optionally overrides the view's default scope of introspection.
     ///   - customize: A closure that hands over the underlying UIKit/AppKit instance ready for customization.
     ///
     /// Here's an example usage:

--- a/Sources/Introspect.swift
+++ b/Sources/Introspect.swift
@@ -29,12 +29,12 @@ extension View {
     ///
     /// ```swift
     /// struct ContentView: View {
-    ///     @State var date = Date()
+    ///     @State var text = ""
     ///
     ///     var body: some View {
-    ///         DatePicker("Pick a date", selection: $date)
-    ///             .introspect(.datePicker, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
-    ///                 print(type(of: $0)) // UIDatePicker
+    ///         TextField("Placeholder", text: $text)
+    ///             .introspect(.textField, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+    ///                 print(type(of: $0)) // UITextField
     ///             }
     ///     }
     /// }

--- a/Sources/Introspect.swift
+++ b/Sources/Introspect.swift
@@ -41,7 +41,7 @@ extension View {
     /// ```
     public func introspect<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity>(
         _ viewType: SwiftUIViewType,
-        on platforms: (PlatformViewVersions<SwiftUIViewType, PlatformSpecificEntity>)...,
+        on platforms: (PlatformViewVersionGroup<SwiftUIViewType, PlatformSpecificEntity>)...,
         scope: IntrospectionScope? = nil,
         customize: @escaping (PlatformSpecificEntity) -> Void
     ) -> some View {
@@ -57,12 +57,12 @@ struct IntrospectModifier<SwiftUIViewType: IntrospectableViewType, PlatformSpeci
 
     init(
         _ viewType: SwiftUIViewType,
-        platforms: [PlatformViewVersions<SwiftUIViewType, PlatformSpecificEntity>],
+        platforms: [PlatformViewVersionGroup<SwiftUIViewType, PlatformSpecificEntity>],
         scope: IntrospectionScope?,
         customize: @escaping (PlatformSpecificEntity) -> Void
     ) {
         self.scope = scope ?? viewType.scope
-        if let platform = platforms.first(where: \.isCurrent) {
+        if let platform = platforms.first(where: \.containsCurrent) {
             self.selector = platform.selector ?? .default
         } else {
             self.selector = nil

--- a/Sources/Introspect.swift
+++ b/Sources/Introspect.swift
@@ -62,11 +62,7 @@ struct IntrospectModifier<SwiftUIViewType: IntrospectableViewType, PlatformSpeci
         customize: @escaping (PlatformSpecificEntity) -> Void
     ) {
         self.scope = scope ?? viewType.scope
-        if let platform = platforms.first(where: \.matches) {
-            self.selector = platform.selector ?? .default
-        } else {
-            self.selector = nil
-        }
+        self.selector = platforms.lazy.compactMap(\.selector).first
         self.customize = customize
     }
 

--- a/Sources/IntrospectionSelector.swift
+++ b/Sources/IntrospectionSelector.swift
@@ -1,4 +1,3 @@
-@_spi(Internals)
 public struct IntrospectionSelector<Target: PlatformEntity> {
     @_spi(Internals)
     public static var `default`: Self { .from(Target.self, selector: { $0 }) }

--- a/Sources/IntrospectionSelector.swift
+++ b/Sources/IntrospectionSelector.swift
@@ -1,3 +1,4 @@
+@_spi(Internals)
 public struct IntrospectionSelector<Target: PlatformEntity> {
     @_spi(Internals)
     public static var `default`: Self { .from(Target.self, selector: { $0 }) }

--- a/Sources/PlatformVersion.swift
+++ b/Sources/PlatformVersion.swift
@@ -11,11 +11,11 @@ public protocol PlatformVersion {
 }
 
 extension PlatformVersion {
-    var isCurrent: Bool {
+    public var isCurrent: Bool {
         condition == .current
     }
 
-    var isCurrentOrPast: Bool {
+    public var isCurrentOrPast: Bool {
         condition == .current || condition == .past
     }
 }

--- a/Sources/PlatformVersion.swift
+++ b/Sources/PlatformVersion.swift
@@ -7,7 +7,7 @@ public enum PlatformVersionCondition {
 }
 
 public protocol PlatformVersion {
-    var condition: PlatformVersionCondition { get }
+    var condition: PlatformVersionCondition? { get }
 }
 
 extension PlatformVersion {
@@ -21,15 +21,16 @@ extension PlatformVersion {
 }
 
 public struct iOSVersion: PlatformVersion {
-    public let condition: PlatformVersionCondition
+    public let condition: PlatformVersionCondition?
 
-    public init(condition: () -> PlatformVersionCondition) {
+    public init(condition: () -> PlatformVersionCondition?) {
         self.condition = condition()
     }
 }
 
 extension iOSVersion {
     public static let v13 = iOSVersion {
+        #if os(iOS)
         if #available(iOS 14, *) {
             return .past
         }
@@ -37,9 +38,13 @@ extension iOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v14 = iOSVersion {
+        #if os(iOS)
         if #available(iOS 15, *) {
             return .past
         }
@@ -47,9 +52,13 @@ extension iOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v15 = iOSVersion {
+        #if os(iOS)
         if #available(iOS 16, *) {
             return .past
         }
@@ -57,9 +66,13 @@ extension iOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v16 = iOSVersion {
+        #if os(iOS)
         if #available(iOS 17, *) {
             return .past
         }
@@ -67,9 +80,13 @@ extension iOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v17 = iOSVersion {
+        #if os(iOS)
         if #available(iOS 18, *) {
             return .past
         }
@@ -77,19 +94,23 @@ extension iOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 }
 
 public struct tvOSVersion: PlatformVersion {
-    public let condition: PlatformVersionCondition
+    public let condition: PlatformVersionCondition?
 
-    public init(condition: () -> PlatformVersionCondition) {
+    public init(condition: () -> PlatformVersionCondition?) {
         self.condition = condition()
     }
 }
 
 extension tvOSVersion {
     public static let v13 = tvOSVersion {
+        #if os(tvOS)
         if #available(tvOS 14, *) {
             return .past
         }
@@ -97,9 +118,13 @@ extension tvOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v14 = tvOSVersion {
+        #if os(tvOS)
         if #available(tvOS 15, *) {
             return .past
         }
@@ -107,9 +132,13 @@ extension tvOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v15 = tvOSVersion {
+        #if os(tvOS)
         if #available(tvOS 16, *) {
             return .past
         }
@@ -117,9 +146,13 @@ extension tvOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v16 = tvOSVersion {
+        #if os(tvOS)
         if #available(tvOS 17, *) {
             return .past
         }
@@ -127,9 +160,13 @@ extension tvOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v17 = tvOSVersion {
+        #if os(tvOS)
         if #available(tvOS 18, *) {
             return .past
         }
@@ -137,19 +174,23 @@ extension tvOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 }
 
 public struct macOSVersion: PlatformVersion {
-    public let condition: PlatformVersionCondition
+    public let condition: PlatformVersionCondition?
 
-    public init(condition: () -> PlatformVersionCondition) {
+    public init(condition: () -> PlatformVersionCondition?) {
         self.condition = condition()
     }
 }
 
 extension macOSVersion {
     public static let v10_15 = macOSVersion {
+        #if os(macOS)
         if #available(macOS 11, *) {
             return .past
         }
@@ -157,9 +198,13 @@ extension macOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v10_15_4 = macOSVersion {
+        #if os(macOS)
         if #available(macOS 11, *) {
             return .past
         }
@@ -167,9 +212,13 @@ extension macOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v11 = macOSVersion {
+        #if os(macOS)
         if #available(macOS 12, *) {
             return .past
         }
@@ -177,9 +226,13 @@ extension macOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v12 = macOSVersion {
+        #if os(macOS)
         if #available(macOS 13, *) {
             return .past
         }
@@ -187,9 +240,13 @@ extension macOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v13 = macOSVersion {
+        #if os(macOS)
         if #available(macOS 14, *) {
             return .past
         }
@@ -197,9 +254,13 @@ extension macOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 
     public static let v14 = macOSVersion {
+        #if os(macOS)
         if #available(macOS 15, *) {
             return .past
         }
@@ -207,5 +268,8 @@ extension macOSVersion {
             return .current
         }
         return .future
+        #else
+        return nil
+        #endif
     }
 }

--- a/Sources/PlatformVersion.swift
+++ b/Sources/PlatformVersion.swift
@@ -1,195 +1,211 @@
 import Foundation
 
+public enum PlatformVersionCondition {
+    case past
+    case current
+    case future
+}
+
 public protocol PlatformVersion {
-    var isCurrent: Bool { get }
+    var condition: PlatformVersionCondition { get }
+}
+
+extension PlatformVersion {
+    var isCurrent: Bool {
+        condition == .current
+    }
+
+    var isCurrentOrPast: Bool {
+        condition == .current || condition == .past
+    }
 }
 
 public struct iOSVersion: PlatformVersion {
-    public let isCurrent: Bool
+    public let condition: PlatformVersionCondition
 
-    public init(isCurrent: () -> Bool) {
-        self.isCurrent = isCurrent()
+    public init(condition: () -> PlatformVersionCondition) {
+        self.condition = condition()
     }
 }
 
 extension iOSVersion {
     public static let v13 = iOSVersion {
         if #available(iOS 14, *) {
-            return false
+            return .past
         }
         if #available(iOS 13, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v14 = iOSVersion {
         if #available(iOS 15, *) {
-            return false
+            return .past
         }
         if #available(iOS 14, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v15 = iOSVersion {
         if #available(iOS 16, *) {
-            return false
+            return .past
         }
         if #available(iOS 15, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v16 = iOSVersion {
         if #available(iOS 17, *) {
-            return false
+            return .past
         }
         if #available(iOS 16, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v17 = iOSVersion {
         if #available(iOS 18, *) {
-            return false
+            return .past
         }
         if #available(iOS 17, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 }
 
 public struct tvOSVersion: PlatformVersion {
-    public let isCurrent: Bool
+    public let condition: PlatformVersionCondition
 
-    public init(isCurrent: () -> Bool) {
-        self.isCurrent = isCurrent()
+    public init(condition: () -> PlatformVersionCondition) {
+        self.condition = condition()
     }
 }
 
 extension tvOSVersion {
     public static let v13 = tvOSVersion {
         if #available(tvOS 14, *) {
-            return false
+            return .past
         }
         if #available(tvOS 13, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v14 = tvOSVersion {
         if #available(tvOS 15, *) {
-            return false
+            return .past
         }
         if #available(tvOS 14, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v15 = tvOSVersion {
         if #available(tvOS 16, *) {
-            return false
+            return .past
         }
         if #available(tvOS 15, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v16 = tvOSVersion {
         if #available(tvOS 17, *) {
-            return false
+            return .past
         }
         if #available(tvOS 16, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v17 = tvOSVersion {
         if #available(tvOS 18, *) {
-            return false
+            return .past
         }
         if #available(tvOS 17, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 }
 
 public struct macOSVersion: PlatformVersion {
-    public let isCurrent: Bool
+    public let condition: PlatformVersionCondition
 
-    public init(isCurrent: () -> Bool) {
-        self.isCurrent = isCurrent()
+    public init(condition: () -> PlatformVersionCondition) {
+        self.condition = condition()
     }
 }
 
 extension macOSVersion {
     public static let v10_15 = macOSVersion {
         if #available(macOS 11, *) {
-            return false
+            return .past
         }
         if #available(macOS 10.15, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v10_15_4 = macOSVersion {
         if #available(macOS 11, *) {
-            return false
+            return .past
         }
         if #available(macOS 10.15.4, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v11 = macOSVersion {
         if #available(macOS 12, *) {
-            return false
+            return .past
         }
         if #available(macOS 11, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v12 = macOSVersion {
         if #available(macOS 13, *) {
-            return false
+            return .past
         }
         if #available(macOS 12, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v13 = macOSVersion {
         if #available(macOS 14, *) {
-            return false
+            return .past
         }
         if #available(macOS 13, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 
     public static let v14 = macOSVersion {
         if #available(macOS 15, *) {
-            return false
+            return .past
         }
         if #available(macOS 14, *) {
-            return true
+            return .current
         }
-        return false
+        return .future
     }
 }

--- a/Sources/PlatformViewVersion.swift
+++ b/Sources/PlatformViewVersion.swift
@@ -53,30 +53,6 @@ public enum PlatformViewVersion<Version: PlatformVersion, SwiftUIViewType: Intro
     @_spi(Private) case available(Version, IntrospectionSelector<PlatformSpecificEntity>?)
     @_spi(Private) case unavailable
 
-    var version: Version? {
-        if case .available(let version, _) = self {
-            return version
-        } else {
-            return nil
-        }
-    }
-
-    var selector: IntrospectionSelector<PlatformSpecificEntity>? {
-        if case .available(_, let selector) = self {
-            return selector
-        } else {
-            return nil
-        }
-    }
-
-    var isCurrent: Bool {
-        version?.isCurrent ?? false
-    }
-
-    var isCurrentOrPast: Bool {
-        version?.isCurrentOrPast ?? false
-    }
-
     @_spi(Internals) public init(for version: Version, selector: IntrospectionSelector<PlatformSpecificEntity>? = nil) {
         self = .available(version, selector)
     }
@@ -96,6 +72,30 @@ public enum PlatformViewVersion<Version: PlatformVersion, SwiftUIViewType: Intro
             """
         )
         return .unavailable
+    }
+
+    private var version: Version? {
+        if case .available(let version, _) = self {
+            return version
+        } else {
+            return nil
+        }
+    }
+
+    fileprivate var selector: IntrospectionSelector<PlatformSpecificEntity>? {
+        if case .available(_, let selector) = self {
+            return selector
+        } else {
+            return nil
+        }
+    }
+
+    fileprivate var isCurrent: Bool {
+        version?.isCurrent ?? false
+    }
+
+    fileprivate var isCurrentOrPast: Bool {
+        version?.isCurrentOrPast ?? false
     }
 }
 

--- a/Sources/PlatformViewVersion.swift
+++ b/Sources/PlatformViewVersion.swift
@@ -3,7 +3,7 @@ import SwiftUI
 public struct PlatformViewVersionPredicate<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity> {
     let matches: Bool
     let selector: IntrospectionSelector<PlatformSpecificEntity>?
-    
+
     private init<Version: PlatformVersion>(
         _ versions: [PlatformViewVersion<Version, SwiftUIViewType, PlatformSpecificEntity>],
         matcher: (PlatformViewVersion<Version, SwiftUIViewType, PlatformSpecificEntity>) -> Bool
@@ -16,16 +16,16 @@ public struct PlatformViewVersionPredicate<SwiftUIViewType: IntrospectableViewTy
             self.selector = nil
         }
     }
-    
+
     public static func iOS(_ versions: (iOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>)...) -> Self {
         Self(versions, matcher: \.isCurrent)
     }
-    
+
     @_spi(Advanced)
     public static func iOS(_ versions: PartialRangeFrom<iOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>>) -> Self {
         Self([versions.lowerBound], matcher: \.isCurrentOrPast)
     }
-    
+
     public static func tvOS(_ versions: (tvOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>)...) -> Self {
         Self(versions, matcher: \.isCurrent)
     }

--- a/Sources/PlatformViewVersion.swift
+++ b/Sources/PlatformViewVersion.swift
@@ -29,6 +29,36 @@ public struct PlatformViewVersionGroup<SwiftUIViewType: IntrospectableViewType, 
     }
 }
 
+@_spi(Advanced)
+public struct PlatformViewVersionSingle<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity> {
+    let isCurrentOrPast: Bool
+    let selector: IntrospectionSelector<PlatformSpecificEntity>?
+
+    private init<Version: PlatformVersion>(
+        _ version: PlatformViewVersion<Version, SwiftUIViewType, PlatformSpecificEntity>
+    ) {
+        if version.isCurrentOrPast {
+            self.isCurrentOrPast = true
+            self.selector = version.selector
+        } else {
+            self.isCurrentOrPast = false
+            self.selector = nil
+        }
+    }
+
+    public static func iOS(_ version: iOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>) -> Self {
+        Self(version)
+    }
+
+    public static func tvOS(_ version: tvOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>) -> Self {
+        Self(version)
+    }
+
+    public static func macOS(_ version: macOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>) -> Self {
+        Self(version)
+    }
+}
+
 public typealias iOSViewVersion<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity> =
     PlatformViewVersion<iOSVersion, SwiftUIViewType, PlatformSpecificEntity>
 public typealias tvOSViewVersion<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity> =

--- a/Sources/PlatformViewVersion.swift
+++ b/Sources/PlatformViewVersion.swift
@@ -67,8 +67,8 @@ public typealias macOSViewVersion<SwiftUIViewType: IntrospectableViewType, Platf
     PlatformViewVersion<macOSVersion, SwiftUIViewType, PlatformSpecificEntity>
 
 public enum PlatformViewVersion<Version: PlatformVersion, SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity> {
-    case available(Version, IntrospectionSelector<PlatformSpecificEntity>?)
-    case unavailable
+    @_spi(Private) case available(Version, IntrospectionSelector<PlatformSpecificEntity>?)
+    @_spi(Private) case unavailable
 
     var isCurrent: Bool {
         switch self {

--- a/Sources/PlatformViewVersion.swift
+++ b/Sources/PlatformViewVersion.swift
@@ -107,12 +107,14 @@ extension PlatformViewVersion {
     }
 }
 
+// This conformance isn't meant to be used directly by the user,
+// it's only to satisfy requirements for forming ranges (e.g. `.v15...`).
 extension PlatformViewVersion: Comparable {
-    public static func < (lhs: Self, rhs: Self) -> Bool {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         true
     }
-    
-    public static func == (lhs: Self, rhs: Self) -> Bool {
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
         true
     }
 }

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		D50E2F782A2B9F6600BAFB03 /* StepperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58119D12A23A77C0081F853 /* StepperTests.swift */; };
 		D50E2F792A2B9F6600BAFB03 /* ColorPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58119D92A23B7700081F853 /* ColorPickerTests.swift */; };
 		D50E2F7A2A2B9F6600BAFB03 /* ToggleWithButtonStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D575068D2A27D4DC00A628E4 /* ToggleWithButtonStyleTests.swift */; };
-		D50E2F7B2A2B9F6600BAFB03 /* PlatformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F0BE6729C0DC4900AD95AB /* PlatformTests.swift */; };
+		D50E2F7B2A2B9F6600BAFB03 /* PlatformVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F0BE6729C0DC4900AD95AB /* PlatformVersionTests.swift */; };
 		D50E2F7C2A2B9F6600BAFB03 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58CE15729C621DD0081BFB0 /* TestUtils.swift */; };
 		D50E2F7D2A2B9F6600BAFB03 /* PickerWithSegmentedStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57506772A27BBBD00A628E4 /* PickerWithSegmentedStyleTests.swift */; };
 		D50E2F7E2A2B9F6600BAFB03 /* TabViewWithPageStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58119CD2A23A4A70081F853 /* TabViewWithPageStyleTests.swift */; };
@@ -109,7 +109,7 @@
 		D5ADFAD72A4A4653009494FD /* PopoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5ADFACF2A4A3E54009494FD /* PopoverTests.swift */; };
 		D5B67B842A0D318F007D5D9B /* TextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B67B832A0D318F007D5D9B /* TextFieldTests.swift */; };
 		D5F0BE4D29C0DBE800AD95AB /* TestsHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F0BE4C29C0DBE800AD95AB /* TestsHostApp.swift */; };
-		D5F0BE6A29C0DC4900AD95AB /* PlatformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F0BE6729C0DC4900AD95AB /* PlatformTests.swift */; };
+		D5F0BE6A29C0DC4900AD95AB /* PlatformVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F0BE6729C0DC4900AD95AB /* PlatformVersionTests.swift */; };
 		D5F8D5ED2A1E7B490054E9AB /* NavigationViewWithStackStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F8D5EC2A1E7B490054E9AB /* NavigationViewWithStackStyleTests.swift */; };
 		D5F8D5EF2A1E87950054E9AB /* NavigationViewWithColumnsStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F8D5EE2A1E87950054E9AB /* NavigationViewWithColumnsStyleTests.swift */; };
 /* End PBXBuildFile section */
@@ -193,7 +193,7 @@
 		D5F0BE4929C0DBE800AD95AB /* TestsHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestsHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5F0BE4C29C0DBE800AD95AB /* TestsHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestsHostApp.swift; sourceTree = "<group>"; };
 		D5F0BE5D29C0DC0000AD95AB /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D5F0BE6729C0DC4900AD95AB /* PlatformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlatformTests.swift; sourceTree = "<group>"; };
+		D5F0BE6729C0DC4900AD95AB /* PlatformVersionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlatformVersionTests.swift; sourceTree = "<group>"; };
 		D5F8D5EC2A1E7B490054E9AB /* NavigationViewWithStackStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewWithStackStyleTests.swift; sourceTree = "<group>"; };
 		D5F8D5EE2A1E87950054E9AB /* NavigationViewWithColumnsStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewWithColumnsStyleTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -330,7 +330,7 @@
 			isa = PBXGroup;
 			children = (
 				D5B67B852A0D3193007D5D9B /* ViewTypes */,
-				D5F0BE6729C0DC4900AD95AB /* PlatformTests.swift */,
+				D5F0BE6729C0DC4900AD95AB /* PlatformVersionTests.swift */,
 				D58CE15729C621DD0081BFB0 /* TestUtils.swift */,
 			);
 			path = Tests;
@@ -545,7 +545,7 @@
 				D50E2F782A2B9F6600BAFB03 /* StepperTests.swift in Sources */,
 				D50E2F792A2B9F6600BAFB03 /* ColorPickerTests.swift in Sources */,
 				D50E2F7A2A2B9F6600BAFB03 /* ToggleWithButtonStyleTests.swift in Sources */,
-				D50E2F7B2A2B9F6600BAFB03 /* PlatformTests.swift in Sources */,
+				D50E2F7B2A2B9F6600BAFB03 /* PlatformVersionTests.swift in Sources */,
 				D50E2F7C2A2B9F6600BAFB03 /* TestUtils.swift in Sources */,
 				D50E2F7D2A2B9F6600BAFB03 /* PickerWithSegmentedStyleTests.swift in Sources */,
 				D50E2F7E2A2B9F6600BAFB03 /* TabViewWithPageStyleTests.swift in Sources */,
@@ -610,7 +610,7 @@
 				D5ADFAD22A4A41CB009494FD /* SignInWithAppleButtonTests.swift in Sources */,
 				D58119DA2A23B7700081F853 /* ColorPickerTests.swift in Sources */,
 				D575068E2A27D4DC00A628E4 /* ToggleWithButtonStyleTests.swift in Sources */,
-				D5F0BE6A29C0DC4900AD95AB /* PlatformTests.swift in Sources */,
+				D5F0BE6A29C0DC4900AD95AB /* PlatformVersionTests.swift in Sources */,
 				D58CE15829C621DD0081BFB0 /* TestUtils.swift in Sources */,
 				D57506782A27BBBD00A628E4 /* PickerWithSegmentedStyleTests.swift in Sources */,
 				D58119CE2A23A4A70081F853 /* TabViewWithPageStyleTests.swift in Sources */,

--- a/Tests/Tests/PlatformTests.swift
+++ b/Tests/Tests/PlatformTests.swift
@@ -1,4 +1,4 @@
-import SwiftUIIntrospect
+@testable import SwiftUIIntrospect
 import XCTest
 
 final class PlatformTests: XCTestCase {

--- a/Tests/Tests/PlatformVersionTests.swift
+++ b/Tests/Tests/PlatformVersionTests.swift
@@ -2,7 +2,7 @@ import SwiftUIIntrospect
 import XCTest
 
 final class PlatformVersionTests: XCTestCase {
-    func test_iOS() {
+    func test_iOS_isCurrent() {
         #if os(iOS)
         if #available(iOS 17, *) {
             XCTAssertEqual(iOSVersion.v17.isCurrent, true)
@@ -44,7 +44,49 @@ final class PlatformVersionTests: XCTestCase {
         #endif
     }
 
-    func test_macOS() {
+    func test_iOS_isCurrentOrPast() {
+        #if os(iOS)
+        if #available(iOS 17, *) {
+            XCTAssertEqual(iOSVersion.v17.isCurrentOrPast, true)
+            XCTAssertEqual(iOSVersion.v16.isCurrentOrPast, true)
+            XCTAssertEqual(iOSVersion.v15.isCurrentOrPast, true)
+            XCTAssertEqual(iOSVersion.v14.isCurrentOrPast, true)
+            XCTAssertEqual(iOSVersion.v13.isCurrentOrPast, true)
+        } else if #available(iOS 16, *) {
+            XCTAssertEqual(iOSVersion.v17.isCurrentOrPast, false)
+            XCTAssertEqual(iOSVersion.v16.isCurrentOrPast, true)
+            XCTAssertEqual(iOSVersion.v15.isCurrentOrPast, true)
+            XCTAssertEqual(iOSVersion.v14.isCurrentOrPast, true)
+            XCTAssertEqual(iOSVersion.v13.isCurrentOrPast, true)
+        } else if #available(iOS 15, *) {
+            XCTAssertEqual(iOSVersion.v17.isCurrentOrPast, false)
+            XCTAssertEqual(iOSVersion.v16.isCurrentOrPast, false)
+            XCTAssertEqual(iOSVersion.v15.isCurrentOrPast, true)
+            XCTAssertEqual(iOSVersion.v14.isCurrentOrPast, true)
+            XCTAssertEqual(iOSVersion.v13.isCurrentOrPast, true)
+        } else if #available(iOS 14, *) {
+            XCTAssertEqual(iOSVersion.v17.isCurrentOrPast, false)
+            XCTAssertEqual(iOSVersion.v16.isCurrentOrPast, false)
+            XCTAssertEqual(iOSVersion.v15.isCurrentOrPast, false)
+            XCTAssertEqual(iOSVersion.v14.isCurrentOrPast, true)
+            XCTAssertEqual(iOSVersion.v13.isCurrentOrPast, true)
+        } else if #available(iOS 13, *) {
+            XCTAssertEqual(iOSVersion.v17.isCurrentOrPast, false)
+            XCTAssertEqual(iOSVersion.v16.isCurrentOrPast, false)
+            XCTAssertEqual(iOSVersion.v15.isCurrentOrPast, false)
+            XCTAssertEqual(iOSVersion.v14.isCurrentOrPast, false)
+            XCTAssertEqual(iOSVersion.v13.isCurrentOrPast, true)
+        }
+        #else
+        XCTAssertEqual(iOSVersion.v17.isCurrentOrPast, false)
+        XCTAssertEqual(iOSVersion.v16.isCurrentOrPast, false)
+        XCTAssertEqual(iOSVersion.v15.isCurrentOrPast, false)
+        XCTAssertEqual(iOSVersion.v14.isCurrentOrPast, false)
+        XCTAssertEqual(iOSVersion.v13.isCurrentOrPast, false)
+        #endif
+    }
+
+    func test_macOS_isCurrent() {
         #if os(macOS)
         if #available(macOS 14, *) {
             XCTAssertEqual(macOSVersion.v14.isCurrent, true)
@@ -86,7 +128,49 @@ final class PlatformVersionTests: XCTestCase {
         #endif
     }
 
-    func test_tvOS() {
+    func test_macOS_isCurrentOrPast() {
+        #if os(macOS)
+        if #available(macOS 14, *) {
+            XCTAssertEqual(macOSVersion.v14.isCurrentOrPast, true)
+            XCTAssertEqual(macOSVersion.v13.isCurrentOrPast, true)
+            XCTAssertEqual(macOSVersion.v12.isCurrentOrPast, true)
+            XCTAssertEqual(macOSVersion.v11.isCurrentOrPast, true)
+            XCTAssertEqual(macOSVersion.v10_15.isCurrentOrPast, true)
+        } else if #available(macOS 13, *) {
+            XCTAssertEqual(macOSVersion.v14.isCurrentOrPast, false)
+            XCTAssertEqual(macOSVersion.v13.isCurrentOrPast, true)
+            XCTAssertEqual(macOSVersion.v12.isCurrentOrPast, true)
+            XCTAssertEqual(macOSVersion.v11.isCurrentOrPast, true)
+            XCTAssertEqual(macOSVersion.v10_15.isCurrentOrPast, true)
+        } else if #available(macOS 12, *) {
+            XCTAssertEqual(macOSVersion.v14.isCurrentOrPast, false)
+            XCTAssertEqual(macOSVersion.v13.isCurrentOrPast, false)
+            XCTAssertEqual(macOSVersion.v12.isCurrentOrPast, true)
+            XCTAssertEqual(macOSVersion.v11.isCurrentOrPast, true)
+            XCTAssertEqual(macOSVersion.v10_15.isCurrentOrPast, true)
+        } else if #available(macOS 11, *) {
+            XCTAssertEqual(macOSVersion.v14.isCurrentOrPast, false)
+            XCTAssertEqual(macOSVersion.v13.isCurrentOrPast, false)
+            XCTAssertEqual(macOSVersion.v12.isCurrentOrPast, false)
+            XCTAssertEqual(macOSVersion.v11.isCurrentOrPast, true)
+            XCTAssertEqual(macOSVersion.v10_15.isCurrentOrPast, true)
+        } else if #available(macOS 10.15, *) {
+            XCTAssertEqual(macOSVersion.v14.isCurrentOrPast, false)
+            XCTAssertEqual(macOSVersion.v13.isCurrentOrPast, false)
+            XCTAssertEqual(macOSVersion.v12.isCurrentOrPast, false)
+            XCTAssertEqual(macOSVersion.v11.isCurrentOrPast, false)
+            XCTAssertEqual(macOSVersion.v10_15.isCurrentOrPast, true)
+        }
+        #else
+        XCTAssertEqual(macOSVersion.v14.isCurrentOrPast, false)
+        XCTAssertEqual(macOSVersion.v13.isCurrentOrPast, false)
+        XCTAssertEqual(macOSVersion.v12.isCurrentOrPast, false)
+        XCTAssertEqual(macOSVersion.v11.isCurrentOrPast, false)
+        XCTAssertEqual(macOSVersion.v10_15.isCurrentOrPast, false)
+        #endif
+    }
+
+    func test_tvOS_isCurrent() {
         #if os(tvOS)
         if #available(tvOS 17, *) {
             XCTAssertEqual(tvOSVersion.v17.isCurrent, true)
@@ -125,6 +209,48 @@ final class PlatformVersionTests: XCTestCase {
         XCTAssertEqual(tvOSVersion.v15.isCurrent, false)
         XCTAssertEqual(tvOSVersion.v14.isCurrent, false)
         XCTAssertEqual(tvOSVersion.v13.isCurrent, false)
+        #endif
+    }
+
+    func test_tvOS_isCurrentOrPast() {
+        #if os(tvOS)
+        if #available(tvOS 17, *) {
+            XCTAssertEqual(tvOSVersion.v17.isCurrentOrPast, true)
+            XCTAssertEqual(tvOSVersion.v16.isCurrentOrPast, true)
+            XCTAssertEqual(tvOSVersion.v15.isCurrentOrPast, true)
+            XCTAssertEqual(tvOSVersion.v14.isCurrentOrPast, true)
+            XCTAssertEqual(tvOSVersion.v13.isCurrentOrPast, true)
+        } else if #available(tvOS 16, *) {
+            XCTAssertEqual(tvOSVersion.v17.isCurrentOrPast, false)
+            XCTAssertEqual(tvOSVersion.v16.isCurrentOrPast, true)
+            XCTAssertEqual(tvOSVersion.v15.isCurrentOrPast, true)
+            XCTAssertEqual(tvOSVersion.v14.isCurrentOrPast, true)
+            XCTAssertEqual(tvOSVersion.v13.isCurrentOrPast, true)
+        } else if #available(tvOS 15, *) {
+            XCTAssertEqual(tvOSVersion.v17.isCurrentOrPast, false)
+            XCTAssertEqual(tvOSVersion.v16.isCurrentOrPast, false)
+            XCTAssertEqual(tvOSVersion.v15.isCurrentOrPast, true)
+            XCTAssertEqual(tvOSVersion.v14.isCurrentOrPast, true)
+            XCTAssertEqual(tvOSVersion.v13.isCurrentOrPast, true)
+        } else if #available(tvOS 14, *) {
+            XCTAssertEqual(tvOSVersion.v17.isCurrentOrPast, false)
+            XCTAssertEqual(tvOSVersion.v16.isCurrentOrPast, false)
+            XCTAssertEqual(tvOSVersion.v15.isCurrentOrPast, false)
+            XCTAssertEqual(tvOSVersion.v14.isCurrentOrPast, true)
+            XCTAssertEqual(tvOSVersion.v13.isCurrentOrPast, true)
+        } else if #available(tvOS 13, *) {
+            XCTAssertEqual(tvOSVersion.v17.isCurrentOrPast, false)
+            XCTAssertEqual(tvOSVersion.v16.isCurrentOrPast, false)
+            XCTAssertEqual(tvOSVersion.v15.isCurrentOrPast, false)
+            XCTAssertEqual(tvOSVersion.v14.isCurrentOrPast, false)
+            XCTAssertEqual(tvOSVersion.v13.isCurrentOrPast, true)
+        }
+        #else
+        XCTAssertEqual(tvOSVersion.v17.isCurrentOrPast, false)
+        XCTAssertEqual(tvOSVersion.v16.isCurrentOrPast, false)
+        XCTAssertEqual(tvOSVersion.v15.isCurrentOrPast, false)
+        XCTAssertEqual(tvOSVersion.v14.isCurrentOrPast, false)
+        XCTAssertEqual(tvOSVersion.v13.isCurrentOrPast, false)
         #endif
     }
 }

--- a/Tests/Tests/PlatformVersionTests.swift
+++ b/Tests/Tests/PlatformVersionTests.swift
@@ -1,4 +1,4 @@
-@testable import SwiftUIIntrospect
+import SwiftUIIntrospect
 import XCTest
 
 final class PlatformVersionTests: XCTestCase {

--- a/Tests/Tests/PlatformVersionTests.swift
+++ b/Tests/Tests/PlatformVersionTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftUIIntrospect
 import XCTest
 
-final class PlatformTests: XCTestCase {
+final class PlatformVersionTests: XCTestCase {
     func test_iOS() {
         #if os(iOS)
         if #available(iOS 17, *) {


### PR DESCRIPTION
This is a different take on #284 without overloading the `introspect` modifier, as suggested by @paescebu.

It reads quite clean, though it's a tiny bit more obscure to find (which might be a good thing, really), and it allows mixing current + current and past matching all in the same expression (which again, might be a good thing).

Examples:

```swift
import SwiftUI
@_spi(Advanced) import SwiftUIIntrospect

struct ContentView: View {
    @State var name = ""

    var body: some View {
        TextField("Name", text: $name)
            .introspect(.textField, on: .iOS(.v13...)) { textField in
                // do something with textField
            }
    }
}
```

```swift
struct ContentView: View {
    var body: some View {
        List {
            Text("Item 1")
            Text("Item 2")
        }
        .introspect(.list, on: .iOS(.v13, .v14, .v15)) { tableView in

        }
        .introspect(.list, on: .iOS(.v16...)) { collectionView in

        }
    }
}
```