### PR TITLE
Only box up content for `.view` introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## master
 
+- Fixed: only box up content for `.view` introspection (#305)
+
 ## [0.9.0]
 
 - Added: view controller introspection (#298)

--- a/Sources/Introspect.swift
+++ b/Sources/Introspect.swift
@@ -70,10 +70,14 @@ struct IntrospectModifier<SwiftUIViewType: IntrospectableViewType, PlatformSpeci
         if let selector {
             content
                 .background(
-                    // boxes up content without affecting appearance or behavior, for more accurate `.view` introspection
-                    Color.white
-                        .opacity(0)
-                        .accessibility(hidden: true)
+                    Group {
+                        // box up content for more accurate `.view` introspection
+                        if SwiftUIViewType.self == ViewType.self {
+                            Color.white
+                                .opacity(0)
+                                .accessibility(hidden: true)
+                        }
+                    }
                 )
                 .background(
                     IntrospectionAnchorView(id: id)


### PR DESCRIPTION
Fixes #304.

Whilst this isn't the most elegant fix, it works. I guess my only reservation with it is that it introduces an ad-hoc piece of logic that can't be replicated outside the core library, but we can probably live with this very narrow edge case.