### PR TITLE
Add `SecureField` introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## master
 
+- Added: `SecureField` introspection (#317)
+
 ## [0.9.2]
 
 - Fixed: occasionally wrong status bar style (#313)

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Introspection
 - [`ProgressView` with `.linear` style](https://swiftpackageindex.com/siteline/swiftui-introspect/master/documentation/swiftuiintrospect/progressviewwithlinearstyletype)
 - [`ScrollView`](https://swiftpackageindex.com/siteline/swiftui-introspect/master/documentation/swiftuiintrospect/scrollviewtype)
 - [`.searchable`](https://swiftpackageindex.com/siteline/swiftui-introspect/master/documentation/swiftuiintrospect/searchfieldtype)
+- [`SecureField`](https://swiftpackageindex.com/siteline/swiftui-introspect/master/documentation/swiftuiintrospect/securefieldtype)
 - [`.sheet`](https://swiftpackageindex.com/siteline/swiftui-introspect/master/documentation/swiftuiintrospect/sheettype)
 - [`SignInWithAppleButton`](https://swiftpackageindex.com/siteline/swiftui-introspect/master/documentation/swiftuiintrospect/SignInWithAppleButtonType)
 - [`Slider`](https://swiftpackageindex.com/siteline/swiftui-introspect/master/documentation/swiftuiintrospect/slidertype)

--- a/Sources/ViewTypes/SecureField.swift
+++ b/Sources/ViewTypes/SecureField.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// An abstract representation of the `SecureField` type in SwiftUI.
+///
+/// ### iOS
+///
+/// ```swift
+/// struct ContentView: View {
+///     @State var text = "Lorem ipsum"
+///
+///     var body: some View {
+///         SecureField("Secure Field", text: $text)
+///             .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///                 print(type(of: $0)) // UISecureField
+///             }
+///     }
+/// }
+/// ```
+///
+/// ### tvOS
+///
+/// ```swift
+/// struct ContentView: View {
+///     @State var text = "Lorem ipsum"
+///
+///     var body: some View {
+///         SecureField("Secure Field", text: $text)
+///             .introspect(.secureField, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///                 print(type(of: $0)) // UISecureField
+///             }
+///     }
+/// }
+/// ```
+///
+/// ### macOS
+///
+/// ```swift
+/// struct ContentView: View {
+///     @State var text = "Lorem ipsum"
+///
+///     var body: some View {
+///         SecureField("Secure Field", text: $text)
+///             .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///                 print(type(of: $0)) // NSSecureField
+///             }
+///     }
+/// }
+/// ```
+public struct SecureFieldType: IntrospectableViewType {}
+
+extension IntrospectableViewType where Self == SecureFieldType {
+    public static var secureField: Self { .init() }
+}
+
+#if canImport(UIKit)
+extension iOSViewVersion<SecureFieldType, UITextField> {
+    public static let v13 = Self(for: .v13)
+    public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
+    public static let v16 = Self(for: .v16)
+    public static let v17 = Self(for: .v17)
+}
+
+extension tvOSViewVersion<SecureFieldType, UITextField> {
+    public static let v13 = Self(for: .v13)
+    public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
+    public static let v16 = Self(for: .v16)
+    public static let v17 = Self(for: .v17)
+}
+#elseif canImport(AppKit)
+extension macOSViewVersion<SecureFieldType, NSTextField> {
+    public static let v10_15 = Self(for: .v10_15)
+    public static let v11 = Self(for: .v11)
+    public static let v12 = Self(for: .v12)
+    public static let v13 = Self(for: .v13)
+    public static let v14 = Self(for: .v14)
+}
+#endif

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		D575069E2A27F80E00A628E4 /* ProgressViewWithLinearStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D575069D2A27F80E00A628E4 /* ProgressViewWithLinearStyleTests.swift */; };
 		D57506A02A27FC0400A628E4 /* TableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D575069F2A27FC0400A628E4 /* TableTests.swift */; };
 		D57506A22A281B9C00A628E4 /* SearchFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57506A12A281B9C00A628E4 /* SearchFieldTests.swift */; };
+		D57E66FA2A6956EB0092F43E /* SecureFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57E66F92A6956EB0092F43E /* SecureFieldTests.swift */; };
 		D58119C42A211B8A0081F853 /* ListCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58119C32A211B8A0081F853 /* ListCellTests.swift */; };
 		D58119C62A227E930081F853 /* ViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58119C52A227E930081F853 /* ViewTests.swift */; };
 		D58119C82A22AC130081F853 /* ToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58119C72A22AC130081F853 /* ToggleTests.swift */; };
@@ -187,6 +188,7 @@
 		D575069D2A27F80E00A628E4 /* ProgressViewWithLinearStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewWithLinearStyleTests.swift; sourceTree = "<group>"; };
 		D575069F2A27FC0400A628E4 /* TableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableTests.swift; sourceTree = "<group>"; };
 		D57506A12A281B9C00A628E4 /* SearchFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFieldTests.swift; sourceTree = "<group>"; };
+		D57E66F92A6956EB0092F43E /* SecureFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureFieldTests.swift; sourceTree = "<group>"; };
 		D58119C32A211B8A0081F853 /* ListCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCellTests.swift; sourceTree = "<group>"; };
 		D58119C52A227E930081F853 /* ViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewTests.swift; sourceTree = "<group>"; };
 		D58119C72A22AC130081F853 /* ToggleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleTests.swift; sourceTree = "<group>"; };
@@ -384,6 +386,7 @@
 				D575069D2A27F80E00A628E4 /* ProgressViewWithLinearStyleTests.swift */,
 				D50FFE8D2A17E2A400C32641 /* ScrollViewTests.swift */,
 				D57506A12A281B9C00A628E4 /* SearchFieldTests.swift */,
+				D57E66F92A6956EB0092F43E /* SecureFieldTests.swift */,
 				D5ADFACB2A4A22AE009494FD /* SheetTests.swift */,
 				D5ADFAD12A4A41CB009494FD /* SignInWithAppleButtonTests.swift */,
 				D58119CF2A23A62C0081F853 /* SliderTests.swift */,
@@ -784,6 +787,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D57E66FA2A6956EB0092F43E /* SecureFieldTests.swift in Sources */,
 				D50FFE8E2A17E2A400C32641 /* ScrollViewTests.swift in Sources */,
 				D58547F82A1CDD740068ADF4 /* NavigationStackTests.swift in Sources */,
 				D57506982A27F32800A628E4 /* DatePickerWithGraphicalStyleTests.swift in Sources */,

--- a/Tests/Tests/ViewTypes/SecureFieldTests.swift
+++ b/Tests/Tests/ViewTypes/SecureFieldTests.swift
@@ -16,7 +16,7 @@ final class SecureFieldTests: XCTestCase {
             let spy2 = spies[2]
 
             VStack {
-                SecureField("", text: .constant("Text Field 0"))
+                SecureField("", text: .constant("Secure Field 0"))
                     #if os(iOS) || os(tvOS)
                     .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy0)
                     #elseif os(macOS)
@@ -24,7 +24,7 @@ final class SecureFieldTests: XCTestCase {
                     #endif
                     .cornerRadius(8)
 
-                SecureField("", text: .constant("Text Field 1"))
+                SecureField("", text: .constant("Secure Field 1"))
                     #if os(iOS) || os(tvOS)
                     .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy1)
                     #elseif os(macOS)
@@ -32,7 +32,7 @@ final class SecureFieldTests: XCTestCase {
                     #endif
                     .cornerRadius(8)
 
-                SecureField("", text: .constant("Text Field 2"))
+                SecureField("", text: .constant("Secure Field 2"))
                     #if os(iOS) || os(tvOS)
                     .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy2)
                     #elseif os(macOS)
@@ -41,13 +41,13 @@ final class SecureFieldTests: XCTestCase {
             }
         } extraAssertions: {
             #if canImport(UIKit)
-            XCTAssertEqual($0[safe: 0]?.text, "Text Field 0")
-            XCTAssertEqual($0[safe: 1]?.text, "Text Field 1")
-            XCTAssertEqual($0[safe: 2]?.text, "Text Field 2")
+            XCTAssertEqual($0[safe: 0]?.text, "Secure Field 0")
+            XCTAssertEqual($0[safe: 1]?.text, "Secure Field 1")
+            XCTAssertEqual($0[safe: 2]?.text, "Secure Field 2")
             #elseif canImport(AppKit)
-            XCTAssertEqual($0[safe: 0]?.stringValue, "Text Field 0")
-            XCTAssertEqual($0[safe: 1]?.stringValue, "Text Field 1")
-            XCTAssertEqual($0[safe: 2]?.stringValue, "Text Field 2")
+            XCTAssertEqual($0[safe: 0]?.stringValue, "Secure Field 0")
+            XCTAssertEqual($0[safe: 1]?.stringValue, "Secure Field 1")
+            XCTAssertEqual($0[safe: 2]?.stringValue, "Secure Field 2")
             #endif
         }
     }
@@ -59,21 +59,21 @@ final class SecureFieldTests: XCTestCase {
             let spy2 = spies[2]
 
             List {
-                SecureField("", text: .constant("Text Field 0"))
+                SecureField("", text: .constant("Secure Field 0"))
                     #if os(iOS) || os(tvOS)
                     .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy0)
                     #elseif os(macOS)
                     .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy0)
                     #endif
 
-                SecureField("", text: .constant("Text Field 1"))
+                SecureField("", text: .constant("Secure Field 1"))
                     #if os(iOS) || os(tvOS)
                     .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy1)
                     #elseif os(macOS)
                     .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy1)
                     #endif
 
-                SecureField("", text: .constant("Text Field 2"))
+                SecureField("", text: .constant("Secure Field 2"))
                     #if os(iOS) || os(tvOS)
                     .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy2)
                     #elseif os(macOS)
@@ -82,13 +82,13 @@ final class SecureFieldTests: XCTestCase {
             }
         } extraAssertions: {
             #if canImport(UIKit)
-            XCTAssertEqual($0[safe: 0]?.text, "Text Field 0")
-            XCTAssertEqual($0[safe: 1]?.text, "Text Field 1")
-            XCTAssertEqual($0[safe: 2]?.text, "Text Field 2")
+            XCTAssertEqual($0[safe: 0]?.text, "Secure Field 0")
+            XCTAssertEqual($0[safe: 1]?.text, "Secure Field 1")
+            XCTAssertEqual($0[safe: 2]?.text, "Secure Field 2")
             #elseif canImport(AppKit)
-            XCTAssertEqual($0[safe: 0]?.stringValue, "Text Field 0")
-            XCTAssertEqual($0[safe: 1]?.stringValue, "Text Field 1")
-            XCTAssertEqual($0[safe: 2]?.stringValue, "Text Field 2")
+            XCTAssertEqual($0[safe: 0]?.stringValue, "Secure Field 0")
+            XCTAssertEqual($0[safe: 1]?.stringValue, "Secure Field 1")
+            XCTAssertEqual($0[safe: 2]?.stringValue, "Secure Field 2")
             #endif
         }
     }

--- a/Tests/Tests/ViewTypes/SecureFieldTests.swift
+++ b/Tests/Tests/ViewTypes/SecureFieldTests.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+import SwiftUIIntrospect
+import XCTest
+
+final class SecureFieldTests: XCTestCase {
+    #if canImport(UIKit)
+    typealias PlatformSecureField = UITextField
+    #elseif canImport(AppKit)
+    typealias PlatformSecureField = NSTextField
+    #endif
+
+    func testSecureField() {
+        XCTAssertViewIntrospection(of: PlatformSecureField.self) { spies in
+            let spy0 = spies[0]
+            let spy1 = spies[1]
+            let spy2 = spies[2]
+
+            VStack {
+                SecureField("", text: .constant("Text Field 0"))
+                    #if os(iOS) || os(tvOS)
+                    .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy0)
+                    #elseif os(macOS)
+                    .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy0)
+                    #endif
+                    .cornerRadius(8)
+
+                SecureField("", text: .constant("Text Field 1"))
+                    #if os(iOS) || os(tvOS)
+                    .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy1)
+                    #elseif os(macOS)
+                    .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy1)
+                    #endif
+                    .cornerRadius(8)
+
+                SecureField("", text: .constant("Text Field 2"))
+                    #if os(iOS) || os(tvOS)
+                    .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy2)
+                    #elseif os(macOS)
+                    .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy2)
+                    #endif
+            }
+        } extraAssertions: {
+            #if canImport(UIKit)
+            XCTAssertEqual($0[safe: 0]?.text, "Text Field 0")
+            XCTAssertEqual($0[safe: 1]?.text, "Text Field 1")
+            XCTAssertEqual($0[safe: 2]?.text, "Text Field 2")
+            #elseif canImport(AppKit)
+            XCTAssertEqual($0[safe: 0]?.stringValue, "Text Field 0")
+            XCTAssertEqual($0[safe: 1]?.stringValue, "Text Field 1")
+            XCTAssertEqual($0[safe: 2]?.stringValue, "Text Field 2")
+            #endif
+        }
+    }
+
+    func testSecureFieldsEmbeddedInList() {
+        XCTAssertViewIntrospection(of: PlatformSecureField.self) { spies in
+            let spy0 = spies[0]
+            let spy1 = spies[1]
+            let spy2 = spies[2]
+
+            List {
+                SecureField("", text: .constant("Text Field 0"))
+                    #if os(iOS) || os(tvOS)
+                    .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy0)
+                    #elseif os(macOS)
+                    .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy0)
+                    #endif
+
+                SecureField("", text: .constant("Text Field 1"))
+                    #if os(iOS) || os(tvOS)
+                    .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy1)
+                    #elseif os(macOS)
+                    .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy1)
+                    #endif
+
+                SecureField("", text: .constant("Text Field 2"))
+                    #if os(iOS) || os(tvOS)
+                    .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17), .tvOS(.v13, .v14, .v15, .v16, .v17), customize: spy2)
+                    #elseif os(macOS)
+                    .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy2)
+                    #endif
+            }
+        } extraAssertions: {
+            #if canImport(UIKit)
+            XCTAssertEqual($0[safe: 0]?.text, "Text Field 0")
+            XCTAssertEqual($0[safe: 1]?.text, "Text Field 1")
+            XCTAssertEqual($0[safe: 2]?.text, "Text Field 2")
+            #elseif canImport(AppKit)
+            XCTAssertEqual($0[safe: 0]?.stringValue, "Text Field 0")
+            XCTAssertEqual($0[safe: 1]?.stringValue, "Text Field 1")
+            XCTAssertEqual($0[safe: 2]?.stringValue, "Text Field 2")
+            #endif
+        }
+    }
+}


### PR DESCRIPTION
Same as `TextField`, but good to have the specific view type to help intuitiveness.

Originates in #316.