### PR TITLE
VisionOS Support

### DIFF
--- a/Introspect/Introspect.swift
+++ b/Introspect/Introspect.swift
@@ -3,14 +3,14 @@ import SwiftUI
 #if os(macOS)
 public typealias PlatformView = NSView
 #endif
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 public typealias PlatformView = UIView
 #endif
 
 #if os(macOS)
 public typealias PlatformViewController = NSViewController
 #endif
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 public typealias PlatformViewController = UIViewController
 #endif
 


### PR DESCRIPTION
This makes a small change to the PlatformView definition so that we can use UIView's on VisionOS. This allows the framework to be compiled and used in native VisionOS apps.