### PR TITLE
Remove `Toggle` introspection on visionOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## master
 
+- Removed: `Toggle` introspection on visionOS (#373)
+
 ## [1.0.0]
 
 - Removed: obsoleted Introspect module (#275)

--- a/Examples/Showcase/Showcase/AppView.swift
+++ b/Examples/Showcase/Showcase/AppView.swift
@@ -408,7 +408,7 @@ struct SimpleElementsShowcase: View {
                     #if os(iOS)
                     .introspect(
                         .toggle,
-                        on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1)
+                        on: .iOS(.v13, .v14, .v15, .v16, .v17)
                     ) { toggle in
                         toggle.backgroundColor = .red
                     }
@@ -422,7 +422,7 @@ struct SimpleElementsShowcase: View {
                     #if os(iOS)
                     .introspect(
                         .toggle,
-                        on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1)
+                        on: .iOS(.v13, .v14, .v15, .v16, .v17)
                     ) { toggle in
                         toggle.backgroundColor = .green
                     }

--- a/Examples/Showcase/Showcase/AppView.swift
+++ b/Examples/Showcase/Showcase/AppView.swift
@@ -401,9 +401,11 @@ struct SimpleElementsShowcase: View {
                     #endif
             }
 
+            #if !os(tvOS)
+            #if !os(visionOS)
             HStack {
                 Toggle("Toggle Red", isOn: $toggleValue)
-                    #if os(iOS) || os(visionOS)
+                    #if os(iOS)
                     .introspect(
                         .toggle,
                         on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1)
@@ -417,7 +419,7 @@ struct SimpleElementsShowcase: View {
                     #endif
 
                 Toggle("Toggle Green", isOn: $toggleValue)
-                    #if os(iOS) || os(visionOS)
+                    #if os(iOS)
                     .introspect(
                         .toggle,
                         on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1)
@@ -431,8 +433,6 @@ struct SimpleElementsShowcase: View {
                     #endif
             }
 
-            #if !os(tvOS)
-            #if !os(visionOS)
             HStack {
                 Slider(value: $sliderValue, in: 0...100)
                     #if os(iOS)

--- a/Sources/ViewTypes/Toggle.swift
+++ b/Sources/ViewTypes/Toggle.swift
@@ -38,21 +38,10 @@ import SwiftUI
 ///
 /// ### visionOS
 ///
-/// ```swift
-/// struct ContentView: View {
-///     @State var isOn = false
-///
-///     var body: some View {
-///         Toggle("Toggle", isOn: $isOn)
-///             .introspect(.toggle, on: .visionOS(.v1)) {
-///                 print(type(of: $0)) // UISwitch
-///             }
-///     }
-/// }
-/// ```
+/// Not available.
 public struct ToggleType: IntrospectableViewType {}
 
-#if !os(tvOS)
+#if !os(tvOS) && !os(visionOS)
 extension IntrospectableViewType where Self == ToggleType {
     public static var toggle: Self { .init() }
 }
@@ -64,10 +53,6 @@ extension iOSViewVersion<ToggleType, UISwitch> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
-}
-
-extension visionOSViewVersion<ToggleType, UISwitch> {
-    public static let v1 = Self(for: .v1)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ToggleType, NSButton> {

--- a/Sources/ViewTypes/ToggleWithSwitchStyle.swift
+++ b/Sources/ViewTypes/ToggleWithSwitchStyle.swift
@@ -40,26 +40,14 @@ import SwiftUI
 ///
 /// ### visionOS
 ///
-/// ```swift
-/// struct ContentView: View {
-///     @State var isOn = false
-///
-///     var body: some View {
-///         Toggle("Switch", isOn: $isOn)
-///             .toggleStyle(.switch)
-///             .introspect(.toggle(style: .switch), on: .visionOS(.v1)) {
-///                 print(type(of: $0)) // UISwitch
-///             }
-///     }
-/// }
-/// ```
+/// Not available.
 public struct ToggleWithSwitchStyleType: IntrospectableViewType {
     public enum Style {
         case `switch`
     }
 }
 
-#if !os(tvOS)
+#if !os(tvOS) && !os(visionOS)
 extension IntrospectableViewType where Self == ToggleWithSwitchStyleType {
     public static func toggle(style: Self.Style) -> Self { .init() }
 }
@@ -71,10 +59,6 @@ extension iOSViewVersion<ToggleWithSwitchStyleType, UISwitch> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
-}
-
-extension visionOSViewVersion<ToggleWithSwitchStyleType, UISwitch> {
-    public static let v1 = Self(for: .v1)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ToggleWithSwitchStyleType, NSSwitch> {

--- a/Tests/Tests/TestUtils.swift
+++ b/Tests/Tests/TestUtils.swift
@@ -3,7 +3,7 @@ import XCTest
 
 #if canImport(UIKit)
 enum TestUtils {
-    #if targetEnvironment(macCatalyst)
+    #if targetEnvironment(macCatalyst) || os(visionOS)
     static let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 480, height: 300))
     #else
     static let window = UIWindow(frame: UIScreen.main.bounds)

--- a/Tests/Tests/ViewTypes/ToggleTests.swift
+++ b/Tests/Tests/ViewTypes/ToggleTests.swift
@@ -1,4 +1,4 @@
-#if !os(tvOS)
+#if !os(tvOS) && !os(visionOS)
 import SwiftUI
 import SwiftUIIntrospect
 import XCTest
@@ -18,21 +18,21 @@ final class ToggleTests: XCTestCase {
 
             VStack {
                 Toggle("", isOn: .constant(true))
-                    #if os(iOS) || os(visionOS)
+                    #if os(iOS)
                     .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy0)
                     #elseif os(macOS)
                     .introspect(.toggle, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy0)
                     #endif
 
                 Toggle("", isOn: .constant(false))
-                    #if os(iOS) || os(visionOS)
+                    #if os(iOS)
                     .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy1)
                     #elseif os(macOS)
                     .introspect(.toggle, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy1)
                     #endif
 
                 Toggle("", isOn: .constant(true))
-                    #if os(iOS) || os(visionOS)
+                    #if os(iOS)
                     .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy2)
                     #elseif os(macOS)
                     .introspect(.toggle, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy2)

--- a/Tests/Tests/ViewTypes/ToggleTests.swift
+++ b/Tests/Tests/ViewTypes/ToggleTests.swift
@@ -19,21 +19,21 @@ final class ToggleTests: XCTestCase {
             VStack {
                 Toggle("", isOn: .constant(true))
                     #if os(iOS)
-                    .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy0)
+                    .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17), customize: spy0)
                     #elseif os(macOS)
                     .introspect(.toggle, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy0)
                     #endif
 
                 Toggle("", isOn: .constant(false))
                     #if os(iOS)
-                    .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy1)
+                    .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17), customize: spy1)
                     #elseif os(macOS)
                     .introspect(.toggle, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy1)
                     #endif
 
                 Toggle("", isOn: .constant(true))
                     #if os(iOS)
-                    .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy2)
+                    .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17), customize: spy2)
                     #elseif os(macOS)
                     .introspect(.toggle, on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy2)
                     #endif

--- a/Tests/Tests/ViewTypes/ToggleWithSwitchStyleTests.swift
+++ b/Tests/Tests/ViewTypes/ToggleWithSwitchStyleTests.swift
@@ -1,4 +1,4 @@
-#if !os(tvOS)
+#if !os(tvOS) && !os(visionOS)
 import SwiftUI
 import SwiftUIIntrospect
 import XCTest
@@ -19,7 +19,7 @@ final class ToggleWithSwitchStyleTests: XCTestCase {
             VStack {
                 Toggle("", isOn: .constant(true))
                     .toggleStyle(.switch)
-                    #if os(iOS) || os(visionOS)
+                    #if os(iOS)
                     .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy0)
                     #elseif os(macOS)
                     .introspect(.toggle(style: .switch), on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy0)
@@ -27,7 +27,7 @@ final class ToggleWithSwitchStyleTests: XCTestCase {
 
                 Toggle("", isOn: .constant(false))
                     .toggleStyle(.switch)
-                    #if os(iOS) || os(visionOS)
+                    #if os(iOS)
                     .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy1)
                     #elseif os(macOS)
                     .introspect(.toggle(style: .switch), on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy1)
@@ -35,7 +35,7 @@ final class ToggleWithSwitchStyleTests: XCTestCase {
 
                 Toggle("", isOn: .constant(true))
                     .toggleStyle(.switch)
-                    #if os(iOS) || os(visionOS)
+                    #if os(iOS)
                     .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy2)
                     #elseif os(macOS)
                     .introspect(.toggle(style: .switch), on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy2)

--- a/Tests/Tests/ViewTypes/ToggleWithSwitchStyleTests.swift
+++ b/Tests/Tests/ViewTypes/ToggleWithSwitchStyleTests.swift
@@ -20,7 +20,7 @@ final class ToggleWithSwitchStyleTests: XCTestCase {
                 Toggle("", isOn: .constant(true))
                     .toggleStyle(.switch)
                     #if os(iOS)
-                    .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy0)
+                    .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17), customize: spy0)
                     #elseif os(macOS)
                     .introspect(.toggle(style: .switch), on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy0)
                     #endif
@@ -28,7 +28,7 @@ final class ToggleWithSwitchStyleTests: XCTestCase {
                 Toggle("", isOn: .constant(false))
                     .toggleStyle(.switch)
                     #if os(iOS)
-                    .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy1)
+                    .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17), customize: spy1)
                     #elseif os(macOS)
                     .introspect(.toggle(style: .switch), on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy1)
                     #endif
@@ -36,7 +36,7 @@ final class ToggleWithSwitchStyleTests: XCTestCase {
                 Toggle("", isOn: .constant(true))
                     .toggleStyle(.switch)
                     #if os(iOS)
-                    .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17), .visionOS(.v1), customize: spy2)
+                    .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17), customize: spy2)
                     #elseif os(macOS)
                     .introspect(.toggle(style: .switch), on: .macOS(.v10_15, .v11, .v12, .v13, .v14), customize: spy2)
                     #endif


### PR DESCRIPTION
visionOS 1.0 beta 4 changed the underlying `Toggle` implementation and is no longer backed by a UIKit view, so sadly we'll need to remove this.

As visionOS 1.0 is still technically considered beta I don't consider this worthy of a major library version bump, so next version will simply be 1.1.0.