### PR TITLE
Fix "Protocol requirement cannot be declared '@_spi'"

### DIFF
--- a/Sources/PlatformVersion.swift
+++ b/Sources/PlatformVersion.swift
@@ -23,6 +23,9 @@ extension PlatformVersion {
     public var isCurrentOrPast: Bool {
         condition == .current || condition == .past
     }
+  
+    @_spi(Internals)
+    public var condition: PlatformVersionCondition? { nil }
 }
 
 public struct iOSVersion: PlatformVersion {


### PR DESCRIPTION
Fixes "Protocol requirement ... cannot be declared '@_spi' ..." error 
that happens with compile flag BUILD_LIBRARY_FOR_DISTRIBUTION=YES

This issue was reported and fixed once before but reappears after the latest code changes
https://github.com/siteline/swiftui-introspect/issues/336

Applied same fix as in https://github.com/siteline/swiftui-introspect/pull/339