### PR TITLE
Add new platform versions for WWDC24

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ struct ContentView: View {
 }
 ```
 
-Bear in mind this should be used cautiously, and with full knowledge that any future OS version might break the expected introspection types unless explicitly available. For instance, if in the example above hypothetically iOS 18 stops using UIScrollView under the hood, the customization closure will never be called on said platform.
+Bear in mind this should be used cautiously, and with full knowledge that any future OS version might break the expected introspection types unless explicitly available. For instance, if in the example above hypothetically iOS 19 stops using UIScrollView under the hood, the customization closure will never be called on said platform.
 
 ### Keep instances outside the customize closure
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For instance, when introspecting a `ScrollView`...
 ScrollView {
     Text("Item 1")
 }
-.introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17)) { scrollView in
+.introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) { scrollView in
     // do something with UIScrollView
 }
 ```
@@ -38,7 +38,7 @@ By default, the `.introspect` modifier acts directly on its _receiver_. This mea
 ```swift
 ScrollView {
     Text("Item 1")
-        .introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17), scope: .ancestor) { scrollView in
+        .introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18), scope: .ancestor) { scrollView in
             // do something with UIScrollView
         }
 }
@@ -157,7 +157,7 @@ List {
     tableView.backgroundView = UIView()
     tableView.backgroundColor = .cyan
 }
-.introspect(.list, on: .iOS(.v16, .v17)) { collectionView in
+.introspect(.list, on: .iOS(.v16, .v17, .v18)) { collectionView in
     collectionView.backgroundView = UIView()
     collectionView.subviews.dropFirst(1).first?.backgroundColor = .cyan
 }
@@ -169,7 +169,7 @@ List {
 ScrollView {
     Text("Item")
 }
-.introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17)) { scrollView in
+.introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) { scrollView in
     scrollView.backgroundColor = .red
 }
 ```
@@ -181,7 +181,7 @@ NavigationView {
     Text("Item")
 }
 .navigationViewStyle(.stack)
-.introspect(.navigationView(style: .stack), on: .iOS(.v13, .v14, .v15, .v16, .v17)) { navigationController in
+.introspect(.navigationView(style: .stack), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) { navigationController in
     navigationController.navigationBar.backgroundColor = .cyan
 }
 ```
@@ -190,7 +190,7 @@ NavigationView {
 
 ```swift
 TextField("Text Field", text: <#Binding<String>#>)
-    .introspect(.textField, on: .iOS(.v13, .v14, .v15, .v16, .v17)) { textField in
+    .introspect(.textField, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) { textField in
         textField.backgroundColor = .red
     }
 ```
@@ -286,7 +286,7 @@ struct ContentView: View {
         ScrollView {
             // ...
         }
-        .introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17)) { scrollView in
+        .introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) { scrollView in
             self.scrollView = scrollView
         }
     }

--- a/Sources/PlatformVersion.swift
+++ b/Sources/PlatformVersion.swift
@@ -190,6 +190,20 @@ extension tvOSVersion {
         return nil
         #endif
     }
+    
+    public static let v17 = tvOSVersion {
+#if os(tvOS)
+        if #available(tvOS 18, *) {
+            return .past
+        }
+        if #available(tvOS 17, *) {
+            return .current
+        }
+        return .future
+#else
+        return nil
+#endif
+    }
 
     public static let v18 = tvOSVersion {
         #if os(tvOS)

--- a/Sources/PlatformVersion.swift
+++ b/Sources/PlatformVersion.swift
@@ -191,12 +191,12 @@ extension tvOSVersion {
         #endif
     }
 
-    public static let v17 = tvOSVersion {
+    public static let v18 = tvOSVersion {
         #if os(tvOS)
-        if #available(tvOS 18, *) {
+        if #available(tvOS 19, *) {
             return .past
         }
-        if #available(tvOS 17, *) {
+        if #available(tvOS 18, *) {
             return .current
         }
         return .future

--- a/Sources/PlatformVersion.swift
+++ b/Sources/PlatformVersion.swift
@@ -300,6 +300,20 @@ extension macOSVersion {
         return nil
         #endif
     }
+
+    public static let v15 = macOSVersion {
+        #if os(macOS)
+        if #available(macOS 16, *) {
+            return .past
+        }
+        if #available(macOS 15, *) {
+            return .current
+        }
+        return .future
+        #else
+        return nil
+        #endif
+    }
 }
 
 public struct visionOSVersion: PlatformVersion {

--- a/Sources/PlatformVersion.swift
+++ b/Sources/PlatformVersion.swift
@@ -108,6 +108,20 @@ extension iOSVersion {
         return nil
         #endif
     }
+
+    public static let v18 = iOSVersion {
+        #if os(iOS)
+        if #available(iOS 19, *) {
+            return .past
+        }
+        if #available(iOS 18, *) {
+            return .current
+        }
+        return .future
+        #else
+        return nil
+        #endif
+    }
 }
 
 public struct tvOSVersion: PlatformVersion {

--- a/Sources/PlatformVersion.swift
+++ b/Sources/PlatformVersion.swift
@@ -340,5 +340,19 @@ extension visionOSVersion {
         return nil
         #endif
     }
+
+    public static let v2 = visionOSVersion {
+        #if os(visionOS)
+        if #available(visionOS 3, *) {
+            return .past
+        }
+        if #available(visionOS 2, *) {
+            return .current
+        }
+        return .future
+        #else
+        return nil
+        #endif
+    }
 }
 #endif

--- a/Sources/ViewTypes/Button.swift
+++ b/Sources/ViewTypes/Button.swift
@@ -17,7 +17,7 @@ import SwiftUI
 /// struct ContentView: View {
 ///     var body: some View {
 ///         Button("Action", action: {})
-///             .introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSButton
 ///             }
 ///     }
@@ -41,6 +41,7 @@ extension macOSViewVersion<ButtonType, NSButton> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ColorPicker.swift
+++ b/Sources/ViewTypes/ColorPicker.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         ColorPicker("Pick a color", selection: $color)
-///             .introspect(.colorPicker, on: .iOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.colorPicker, on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIColorPicker
 ///             }
 ///     }
@@ -30,7 +30,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         ColorPicker("Pick a color", selection: $color)
-///             .introspect(.colorPicker, on: .macOS(.v11, .v12, .v13, .v14)) {
+///             .introspect(.colorPicker, on: .macOS(.v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSColorPicker
 ///             }
 ///     }
@@ -67,6 +67,7 @@ extension iOSViewVersion<ColorPickerType, UIColorWell> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 @available(iOS 14, *)
@@ -82,6 +83,7 @@ extension macOSViewVersion<ColorPickerType, NSColorWell> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/DatePicker.swift
+++ b/Sources/ViewTypes/DatePicker.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
-///             .introspect(.datePicker, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.datePicker, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIDatePicker
 ///             }
 ///     }
@@ -28,7 +28,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
-///             .introspect(.datePicker, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.datePicker, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSDatePicker
 ///             }
 ///     }
@@ -43,7 +43,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
-///             .introspect(.datePicker, on: .visionOS(.v1)) {
+///             .introspect(.datePicker, on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UIDatePicker
 ///             }
 ///     }
@@ -63,10 +63,12 @@ extension iOSViewVersion<DatePickerType, UIDatePicker> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<DatePickerType, UIDatePicker> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<DatePickerType, NSDatePicker> {
@@ -75,6 +77,7 @@ extension macOSViewVersion<DatePickerType, NSDatePicker> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/DatePickerWithCompactStyle.swift
+++ b/Sources/ViewTypes/DatePickerWithCompactStyle.swift
@@ -78,7 +78,7 @@ extension iOSViewVersion<DatePickerWithCompactStyleType, UIDatePicker> {
 
 extension visionOSViewVersion<DatePickerWithCompactStyleType, UIDatePicker> {
     public static let v1 = Self(for: .v1)
-    public static let v1 = Self(for: .v2)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit) && !targetEnvironment(macCatalyst)
 extension macOSViewVersion<DatePickerWithCompactStyleType, NSDatePicker> {

--- a/Sources/ViewTypes/DatePickerWithCompactStyle.swift
+++ b/Sources/ViewTypes/DatePickerWithCompactStyle.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
 ///             .datePickerStyle(.compact)
-///             .introspect(.datePicker(style: .compact), on: .iOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.datePicker(style: .compact), on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIDatePicker
 ///             }
 ///     }
@@ -32,7 +32,7 @@ import SwiftUI
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
 ///             .datePickerStyle(.compact)
-///             .introspect(.datePicker(style: .compact), on: .macOS(.v10_15_4, .v11, .v12, .v13, .v14)) {
+///             .introspect(.datePicker(style: .compact), on: .macOS(.v10_15_4, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSDatePicker
 ///             }
 ///     }
@@ -48,7 +48,7 @@ import SwiftUI
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
 ///             .datePickerStyle(.compact)
-///             .introspect(.datePicker(style: .compact), on: .visionOS(.v1)) {
+///             .introspect(.datePicker(style: .compact), on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UIDatePicker
 ///             }
 ///     }
@@ -73,10 +73,12 @@ extension iOSViewVersion<DatePickerWithCompactStyleType, UIDatePicker> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<DatePickerWithCompactStyleType, UIDatePicker> {
     public static let v1 = Self(for: .v1)
+    public static let v1 = Self(for: .v2)
 }
 #elseif canImport(AppKit) && !targetEnvironment(macCatalyst)
 extension macOSViewVersion<DatePickerWithCompactStyleType, NSDatePicker> {
@@ -87,6 +89,7 @@ extension macOSViewVersion<DatePickerWithCompactStyleType, NSDatePicker> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/DatePickerWithFieldStyle.swift
+++ b/Sources/ViewTypes/DatePickerWithFieldStyle.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
 ///             .datePickerStyle(.field)
-///             .introspect(.datePicker(style: .field), on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.datePicker(style: .field), on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSDatePicker
 ///             }
 ///     }
@@ -48,6 +48,7 @@ extension macOSViewVersion<DatePickerWithFieldStyleType, NSDatePicker> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/DatePickerWithGraphicalStyle.swift
+++ b/Sources/ViewTypes/DatePickerWithGraphicalStyle.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
 ///             .datePickerStyle(.graphical)
-///             .introspect(.datePicker(style: .graphical), on: .iOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.datePicker(style: .graphical), on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIDatePicker
 ///             }
 ///     }
@@ -32,7 +32,7 @@ import SwiftUI
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
 ///             .datePickerStyle(.graphical)
-///             .introspect(.datePicker(style: .graphical), on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.datePicker(style: .graphical), on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSDatePicker
 ///             }
 ///     }
@@ -48,7 +48,7 @@ import SwiftUI
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
 ///             .datePickerStyle(.graphical)
-///             .introspect(.datePicker(style: .graphical), on: .visionOS(.v1)) {
+///             .introspect(.datePicker(style: .graphical), on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UIDatePicker
 ///             }
 ///     }
@@ -73,10 +73,12 @@ extension iOSViewVersion<DatePickerWithGraphicalStyleType, UIDatePicker> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<DatePickerWithGraphicalStyleType, UIDatePicker> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit) && !targetEnvironment(macCatalyst)
 extension macOSViewVersion<DatePickerWithGraphicalStyleType, NSDatePicker> {
@@ -85,6 +87,7 @@ extension macOSViewVersion<DatePickerWithGraphicalStyleType, NSDatePicker> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/DatePickerWithStepperFieldStyle.swift
+++ b/Sources/ViewTypes/DatePickerWithStepperFieldStyle.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
 ///             .datePickerStyle(.stepperField)
-///             .introspect(.datePicker(style: .stepperField), on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.datePicker(style: .stepperField), on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSDatePicker
 ///             }
 ///     }
@@ -48,6 +48,7 @@ extension macOSViewVersion<DatePickerWithStepperFieldStyleType, NSDatePicker> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/DatePickerWithWheelStyle.swift
+++ b/Sources/ViewTypes/DatePickerWithWheelStyle.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
 ///             .datePickerStyle(.wheel)
-///             .introspect(.datePicker(style: .wheel), on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.datePicker(style: .wheel), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIDatePicker
 ///             }
 ///     }
@@ -36,7 +36,7 @@ import SwiftUI
 ///     var body: some View {
 ///         DatePicker("Pick a date", selection: $date)
 ///             .datePickerStyle(.wheel)
-///             .introspect(.datePicker(style: .wheel), on: .visionOS(.v1)) {
+///             .introspect(.datePicker(style: .wheel), on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UIDatePicker
 ///             }
 ///     }
@@ -60,10 +60,12 @@ extension iOSViewVersion<DatePickerWithWheelStyleType, UIDatePicker> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<DatePickerWithWheelStyleType, UIDatePicker> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/Form.swift
+++ b/Sources/ViewTypes/Form.swift
@@ -16,7 +16,7 @@ import SwiftUI
 ///         .introspect(.form, on: .iOS(.v13, .v14, .v15)) {
 ///             print(type(of: $0)) // UITableView
 ///         }
-///         .introspect(.form, on: .iOS(.v16, .v17)) {
+///         .introspect(.form, on: .iOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -33,7 +33,7 @@ import SwiftUI
 ///             Text("Item 2")
 ///             Text("Item 3")
 ///         }
-///         .introspect(.form, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.form, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UITableView
 ///         }
 ///     }
@@ -54,7 +54,7 @@ import SwiftUI
 ///             Text("Item 2")
 ///             Text("Item 3")
 ///         }
-///         .introspect(.form, on: .visionOS(.v1)) {
+///         .introspect(.form, on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -77,6 +77,7 @@ extension iOSViewVersion<FormType, UITableView> {
 extension iOSViewVersion<FormType, UICollectionView> {
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<FormType, UITableView> {
@@ -85,10 +86,12 @@ extension tvOSViewVersion<FormType, UITableView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<FormType, UICollectionView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/FormWithGroupedStyle.swift
+++ b/Sources/ViewTypes/FormWithGroupedStyle.swift
@@ -14,7 +14,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .formStyle(.grouped)
-///         .introspect(.form(style: .grouped), on: .iOS(.v16, .v17)) {
+///         .introspect(.form(style: .grouped), on: .iOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -32,7 +32,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .formStyle(.grouped)
-///         .introspect(.form(style: .grouped), on: .tvOS(.v16, .v17)) {
+///         .introspect(.form(style: .grouped), on: .tvOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UITableView
 ///         }
 ///     }
@@ -50,7 +50,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .formStyle(.grouped)
-///         .introspect(.form(style: .grouped), on: .macOS(.v13, .v14)) {
+///         .introspect(.form(style: .grouped), on: .macOS(.v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSScrollView
 ///         }
 ///     }
@@ -68,7 +68,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .formStyle(.grouped)
-///         .introspect(.form(style: .grouped), on: .visionOS(.v1)) {
+///         .introspect(.form(style: .grouped), on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -97,6 +97,7 @@ extension iOSViewVersion<FormWithGroupedStyleType, UITableView> {
 extension iOSViewVersion<FormWithGroupedStyleType, UICollectionView> {
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<FormWithGroupedStyleType, UITableView> {
@@ -108,6 +109,7 @@ extension tvOSViewVersion<FormWithGroupedStyleType, UITableView> {
     public static let v15 = Self.unavailable()
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<FormWithGroupedStyleType, UICollectionView> {
@@ -123,6 +125,7 @@ extension macOSViewVersion<FormWithGroupedStyleType, NSScrollView> {
     public static let v12 = Self.unavailable()
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/FullScreenCover.swift
+++ b/Sources/ViewTypes/FullScreenCover.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///         Button("Present", action: { isPresented = true })
 ///             .fullScreenCover(isPresented: $isPresented) {
 ///                 Button("Dismiss", action: { isPresented = false })
-///                     .introspect(.fullScreenCover, on: .iOS(.v14, .v15, .v16, .v17)) {
+///                     .introspect(.fullScreenCover, on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                         print(type(of: $0)) // UIPresentationController
 ///                     }
 ///             }
@@ -31,7 +31,7 @@ import SwiftUI
 ///         Button("Present", action: { isPresented = true })
 ///             .fullScreenCover(isPresented: $isPresented) {
 ///                 Button("Dismiss", action: { isPresented = false })
-///                     .introspect(.fullScreenCover, on: .tvOS(.v14, .v15, .v16, .v17)) {
+///                     .introspect(.fullScreenCover, on: .tvOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                         print(type(of: $0)) // UIPresentationController
 ///                     }
 ///             }
@@ -53,7 +53,7 @@ import SwiftUI
 ///         Button("Present", action: { isPresented = true })
 ///             .fullScreenCover(isPresented: $isPresented) {
 ///                 Button("Dismiss", action: { isPresented = false })
-///                     .introspect(.fullScreenCover, on: .visionOS(.v1)) {
+///                     .introspect(.fullScreenCover, on: .visionOS(.v1, .v2)) {
 ///                         print(type(of: $0)) // UIPresentationController
 ///                     }
 ///             }
@@ -77,6 +77,7 @@ extension iOSViewVersion<FullScreenCoverType, UIPresentationController> {
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UIPresentationController> {
         .from(UIViewController.self, selector: \.presentationController)
@@ -90,6 +91,7 @@ extension tvOSViewVersion<FullScreenCoverType, UIPresentationController> {
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UIPresentationController> {
         .from(UIViewController.self, selector: \.presentationController)
@@ -98,6 +100,7 @@ extension tvOSViewVersion<FullScreenCoverType, UIPresentationController> {
 
 extension visionOSViewVersion<FullScreenCoverType, UIPresentationController> {
     public static let v1 = Self(for: .v1, selector: selector)
+    public static let v2 = Self(for: .v2, selector: selector)
 
     private static var selector: IntrospectionSelector<UIPresentationController> {
         .from(UIViewController.self, selector: \.presentationController)

--- a/Sources/ViewTypes/List.swift
+++ b/Sources/ViewTypes/List.swift
@@ -16,7 +16,7 @@ import SwiftUI
 ///         .introspect(.list, on: .iOS(.v13, .v14, .v15)) {
 ///             print(type(of: $0)) // UITableView
 ///         }
-///         .introspect(.list, on: .iOS(.v16, .v17)) {
+///         .introspect(.list, on: .iOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -33,7 +33,7 @@ import SwiftUI
 ///             Text("Item 2")
 ///             Text("Item 3")
 ///         }
-///         .introspect(.list, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.list, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UITableView
 ///         }
 ///     }
@@ -50,7 +50,7 @@ import SwiftUI
 ///             Text("Item 2")
 ///             Text("Item 3")
 ///         }
-///         .introspect(.list, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///         .introspect(.list, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSTableView
 ///         }
 ///     }
@@ -67,7 +67,7 @@ import SwiftUI
 ///             Text("Item 2")
 ///             Text("Item 3")
 ///         }
-///         .introspect(.list, on: .visionOS(.v1)) {
+///         .introspect(.list, on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -94,6 +94,7 @@ extension iOSViewVersion<ListType, UITableView> {
 extension iOSViewVersion<ListType, UICollectionView> {
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<ListType, UITableView> {
@@ -102,10 +103,12 @@ extension tvOSViewVersion<ListType, UITableView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ListType, UICollectionView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ListType, NSTableView> {
@@ -114,6 +117,7 @@ extension macOSViewVersion<ListType, NSTableView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ListCell.swift
+++ b/Sources/ViewTypes/ListCell.swift
@@ -14,7 +14,7 @@ import SwiftUI
 ///                     .introspect(.listCell, on: .iOS(.v13, .v14, .v15)) {
 ///                         print(type(of: $0)) // UITableViewCell
 ///                     }
-///                     .introspect(.listCell, on: .iOS(.v16, .v17)) {
+///                     .introspect(.listCell, on: .iOS(.v16, .v17, .v18)) {
 ///                         print(type(of: $0)) // UICollectionViewCell
 ///                     }
 ///             }
@@ -31,7 +31,7 @@ import SwiftUI
 ///         List {
 ///             ForEach(1...3, id: \.self) { int in
 ///                 Text("Item \(int)")
-///                     .introspect(.listCell, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///                     .introspect(.listCell, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                         print(type(of: $0)) // UITableViewCell
 ///                     }
 ///             }
@@ -48,7 +48,7 @@ import SwiftUI
 ///         List {
 ///             ForEach(1...3, id: \.self) { int in
 ///                 Text("Item \(int)")
-///                     .introspect(.listCell, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///                     .introspect(.listCell, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                         print(type(of: $0)) // NSTableCellView
 ///                     }
 ///             }
@@ -65,7 +65,7 @@ import SwiftUI
 ///         List {
 ///             ForEach(1...3, id: \.self) { int in
 ///                 Text("Item \(int)")
-///                     .introspect(.listCell, on: .visionOS(.v1)) {
+///                     .introspect(.listCell, on: .visionOS(.v1, .v2)) {
 ///                         print(type(of: $0)) // UICollectionViewCell
 ///                     }
 ///             }
@@ -91,6 +91,7 @@ extension iOSViewVersion<ListCellType, UITableViewCell> {
 extension iOSViewVersion<ListCellType, UICollectionViewCell> {
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<ListCellType, UITableViewCell> {
@@ -99,10 +100,12 @@ extension tvOSViewVersion<ListCellType, UITableViewCell> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ListCellType, UICollectionViewCell> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ListCellType, NSTableCellView> {
@@ -111,6 +114,7 @@ extension macOSViewVersion<ListCellType, NSTableCellView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ListWithBorderedStyle.swift
+++ b/Sources/ViewTypes/ListWithBorderedStyle.swift
@@ -22,7 +22,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .listStyle(.bordered)
-///         .introspect(.list(style: .bordered), on: .macOS(.v12, .v13, .v14)) {
+///         .introspect(.list(style: .bordered), on: .macOS(.v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSTableView
 ///         }
 ///     }
@@ -52,6 +52,7 @@ extension macOSViewVersion<ListWithBorderedStyleType, NSTableView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ListWithGroupedStyle.swift
+++ b/Sources/ViewTypes/ListWithGroupedStyle.swift
@@ -17,7 +17,7 @@ import SwiftUI
 ///         .introspect(.list(style: .grouped), on: .iOS(.v13, .v14, .v15)) {
 ///             print(type(of: $0)) // UITableView
 ///         }
-///         .introspect(.list(style: .grouped), on: .iOS(.v16, .v17)) {
+///         .introspect(.list(style: .grouped), on: .iOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -35,7 +35,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .listStyle(.grouped)
-///         .introspect(.list(style: .grouped), on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.list(style: .grouped), on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UITableView
 ///         }
 ///     }
@@ -57,7 +57,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .listStyle(.grouped)
-///         .introspect(.list(style: .grouped), on: .visionOS(.v1)) {
+///         .introspect(.list(style: .grouped), on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -84,6 +84,7 @@ extension iOSViewVersion<ListWithGroupedStyleType, UITableView> {
 extension iOSViewVersion<ListWithGroupedStyleType, UICollectionView> {
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<ListWithGroupedStyleType, UITableView> {
@@ -92,10 +93,12 @@ extension tvOSViewVersion<ListWithGroupedStyleType, UITableView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ListWithGroupedStyleType, UICollectionView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ListWithInsetGroupedStyle.swift
+++ b/Sources/ViewTypes/ListWithInsetGroupedStyle.swift
@@ -17,7 +17,7 @@ import SwiftUI
 ///         .introspect(.list(style: .insetGrouped), on: .iOS(.v14, .v15)) {
 ///             print(type(of: $0)) // UITableView
 ///         }
-///         .introspect(.list(style: .insetGrouped), on: .iOS(.v16, .v17)) {
+///         .introspect(.list(style: .insetGrouped), on: .iOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -43,7 +43,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .listStyle(.insetGrouped)
-///         .introspect(.list(style: .insetGrouped), on: .visionOS(.v1)) {
+///         .introspect(.list(style: .insetGrouped), on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -71,10 +71,12 @@ extension iOSViewVersion<ListWithInsetGroupedStyleType, UITableView> {
 extension iOSViewVersion<ListWithInsetGroupedStyleType, UICollectionView> {
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ListWithInsetGroupedStyleType, UICollectionView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ListWithInsetStyle.swift
+++ b/Sources/ViewTypes/ListWithInsetStyle.swift
@@ -17,7 +17,7 @@ import SwiftUI
 ///         .introspect(.list(style: .inset), on: .iOS(.v14, .v15)) {
 ///             print(type(of: $0)) // UITableView
 ///         }
-///         .introspect(.list(style: .inset), on: .iOS(.v16, .v17)) {
+///         .introspect(.list(style: .inset), on: .iOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -39,7 +39,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .listStyle(.inset)
-///         .introspect(.list(style: .inset), on: .macOS(.v11, .v12, .v13, .v14)) {
+///         .introspect(.list(style: .inset), on: .macOS(.v11, .v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSTableView
 ///         }
 ///     }
@@ -57,7 +57,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .listStyle(.inset)
-///         .introspect(.list(style: .inset), on: .visionOS(.v1)) {
+///         .introspect(.list(style: .inset), on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -85,10 +85,12 @@ extension iOSViewVersion<ListWithInsetStyleType, UITableView> {
 extension iOSViewVersion<ListWithInsetStyleType, UICollectionView> {
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ListWithInsetStyleType, UICollectionView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ListWithInsetStyleType, NSTableView> {
@@ -98,6 +100,7 @@ extension macOSViewVersion<ListWithInsetStyleType, NSTableView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ListWithSidebarStyle.swift
+++ b/Sources/ViewTypes/ListWithSidebarStyle.swift
@@ -17,7 +17,7 @@ import SwiftUI
 ///         .introspect(.list(style: .sidebar), on: .iOS(.v14, .v15)) {
 ///             print(type(of: $0)) // UITableView
 ///         }
-///         .introspect(.list(style: .sidebar), on: .iOS(.v16, .v17)) {
+///         .introspect(.list(style: .sidebar), on: .iOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -39,7 +39,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .listStyle(.sidebar)
-///         .introspect(.list(style: .sidebar), on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///         .introspect(.list(style: .sidebar), on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSTableView
 ///         }
 ///     }
@@ -57,7 +57,7 @@ import SwiftUI
 ///             Text("Item 3")
 ///         }
 ///         .listStyle(.sidebar)
-///         .introspect(.list(style: .sidebar), on: .visionOS(.v1)) {
+///         .introspect(.list(style: .sidebar), on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -85,10 +85,12 @@ extension iOSViewVersion<ListWithSidebarStyleType, UITableView> {
 extension iOSViewVersion<ListWithSidebarStyleType, UICollectionView> {
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ListWithSidebarStyleType, UICollectionView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ListWithSidebarStyleType, NSTableView> {
@@ -97,6 +99,7 @@ extension macOSViewVersion<ListWithSidebarStyleType, NSTableView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/Map.swift
+++ b/Sources/ViewTypes/Map.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         Map(coordinateRegion: $region)
-///             .introspect(.map, on: .iOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.map, on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // MKMapView
 ///             }
 ///     }
@@ -26,7 +26,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         Map(coordinateRegion: $region)
-///             .introspect(.map, on: .tvOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.map, on: .tvOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // MKMapView
 ///             }
 ///     }
@@ -41,7 +41,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         Map(coordinateRegion: $region)
-///             .introspect(.map, on: .macOS(.v11, .v12, .v13, .v14)) {
+///             .introspect(.map, on: .macOS(.v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // MKMapView
 ///             }
 ///     }
@@ -56,7 +56,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         Map(coordinateRegion: $region)
-///             .introspect(.map, on: .visionOS(.v1)) {
+///             .introspect(.map, on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // MKMapView
 ///             }
 ///     }
@@ -87,6 +87,7 @@ extension tvOSViewVersion<MapType, MKMapView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension macOSViewVersion<MapType, MKMapView> {
@@ -96,10 +97,12 @@ extension macOSViewVersion<MapType, MKMapView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 
 extension visionOSViewVersion<MapType, MKMapView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/NavigationSplitView.swift
+++ b/Sources/ViewTypes/NavigationSplitView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///         } detail: {
 ///             Text("Detail")
 ///         }
-///         .introspect(.navigationSplitView, on: .iOS(.v16, .v17)) {
+///         .introspect(.navigationSplitView, on: .iOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UISplitViewController
 ///         }
 ///     }
@@ -30,7 +30,7 @@ import SwiftUI
 ///         } detail: {
 ///             Text("Detail")
 ///         }
-///         .introspect(.navigationSplitView, on: .tvOS(.v16, .v17)) {
+///         .introspect(.navigationSplitView, on: .tvOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -47,7 +47,7 @@ import SwiftUI
 ///         } detail: {
 ///             Text("Detail")
 ///         }
-///         .introspect(.navigationSplitView, on: .macOS(.v13, .v14)) {
+///         .introspect(.navigationSplitView, on: .macOS(.v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSSplitView
 ///         }
 ///     }
@@ -64,7 +64,7 @@ import SwiftUI
 ///         } detail: {
 ///             Text("Detail")
 ///         }
-///         .introspect(.navigationSplitView, on: .visionOS(.v1)) {
+///         .introspect(.navigationSplitView, on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UISplitViewController
 ///         }
 ///     }
@@ -87,6 +87,7 @@ extension iOSViewVersion<NavigationSplitViewType, UISplitViewController> {
 
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UISplitViewController> {
         .default.withAncestorSelector(\.splitViewController)
@@ -103,6 +104,7 @@ extension tvOSViewVersion<NavigationSplitViewType, UINavigationController> {
 
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UINavigationController> {
         .default.withAncestorSelector(\.navigationController)
@@ -111,6 +113,7 @@ extension tvOSViewVersion<NavigationSplitViewType, UINavigationController> {
 
 extension visionOSViewVersion<NavigationSplitViewType, UISplitViewController> {
     public static let v1 = Self(for: .v1, selector: selector)
+    public static let v2 = Self(for: .v2, selector: selector)
 
     private static var selector: IntrospectionSelector<UISplitViewController> {
         .default.withAncestorSelector(\.splitViewController)
@@ -127,6 +130,7 @@ extension macOSViewVersion<NavigationSplitViewType, NSSplitView> {
 
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/NavigationStack.swift
+++ b/Sources/ViewTypes/NavigationStack.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///         NavigationStack {
 ///             Text("Root")
 ///         }
-///         .introspect(.navigationStack, on: .iOS(.v16, .v17)) {
+///         .introspect(.navigationStack, on: .iOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -26,7 +26,7 @@ import SwiftUI
 ///         NavigationStack {
 ///             Text("Root")
 ///         }
-///         .introspect(.navigationStack, on: .tvOS(.v16, .v17)) {
+///         .introspect(.navigationStack, on: .tvOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -45,7 +45,7 @@ import SwiftUI
 ///         NavigationStack {
 ///             Text("Root")
 ///         }
-///         .introspect(.navigationStack, on: .visionOS(.v1)) {
+///         .introspect(.navigationStack, on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -68,6 +68,7 @@ extension iOSViewVersion<NavigationStackType, UINavigationController> {
 
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UINavigationController> {
         .default.withAncestorSelector(\.navigationController)
@@ -84,6 +85,7 @@ extension tvOSViewVersion<NavigationStackType, UINavigationController> {
 
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UINavigationController> {
         .default.withAncestorSelector(\.navigationController)
@@ -92,6 +94,7 @@ extension tvOSViewVersion<NavigationStackType, UINavigationController> {
 
 extension visionOSViewVersion<NavigationStackType, UINavigationController> {
     public static let v1 = Self(for: .v1, selector: selector)
+    public static let v2 = Self(for: .v2, selector: selector)
 
     private static var selector: IntrospectionSelector<UINavigationController> {
         .default.withAncestorSelector(\.navigationController)

--- a/Sources/ViewTypes/NavigationViewWithColumnsStyle.swift
+++ b/Sources/ViewTypes/NavigationViewWithColumnsStyle.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///             Text("Root")
 ///         }
 ///         .navigationViewStyle(DoubleColumnNavigationViewStyle())
-///         .introspect(.navigationView(style: .columns), on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.navigationView(style: .columns), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UISplitViewController
 ///         }
 ///     }
@@ -28,7 +28,7 @@ import SwiftUI
 ///             Text("Root")
 ///         }
 ///         .navigationViewStyle(DoubleColumnNavigationViewStyle())
-///         .introspect(.navigationView(style: .columns), on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.navigationView(style: .columns), on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -44,7 +44,7 @@ import SwiftUI
 ///             Text("Root")
 ///         }
 ///         .navigationViewStyle(DoubleColumnNavigationViewStyle())
-///         .introspect(.navigationView(style: .columns), on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///         .introspect(.navigationView(style: .columns), on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSSplitView
 ///         }
 ///     }
@@ -60,7 +60,7 @@ import SwiftUI
 ///             Text("Root")
 ///         }
 ///         .navigationViewStyle(DoubleColumnNavigationViewStyle())
-///         .introspect(.navigationView(style: .columns), on: .visionOS(.v1)) {
+///         .introspect(.navigationView(style: .columns), on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UISplitViewController
 ///         }
 ///     }
@@ -83,6 +83,7 @@ extension iOSViewVersion<NavigationViewWithColumnsStyleType, UISplitViewControll
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UISplitViewController> {
         .default.withAncestorSelector(\.splitViewController)
@@ -95,6 +96,7 @@ extension tvOSViewVersion<NavigationViewWithColumnsStyleType, UINavigationContro
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UINavigationController> {
         .default.withAncestorSelector(\.navigationController)
@@ -103,6 +105,7 @@ extension tvOSViewVersion<NavigationViewWithColumnsStyleType, UINavigationContro
 
 extension visionOSViewVersion<NavigationViewWithColumnsStyleType, UISplitViewController> {
     public static let v1 = Self(for: .v1, selector: selector)
+    public static let v2 = Self(for: .v2, selector: selector)
 
     private static var selector: IntrospectionSelector<UISplitViewController> {
         .default.withAncestorSelector(\.splitViewController)
@@ -115,6 +118,7 @@ extension macOSViewVersion<NavigationViewWithColumnsStyleType, NSSplitView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/NavigationViewWithStackStyle.swift
+++ b/Sources/ViewTypes/NavigationViewWithStackStyle.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///             Text("Root")
 ///         }
 ///         .navigationViewStyle(.stack)
-///         .introspect(.navigationView(style: .stack), on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.navigationView(style: .stack), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -28,7 +28,7 @@ import SwiftUI
 ///             Text("Root")
 ///         }
 ///         .navigationViewStyle(.stack)
-///         .introspect(.navigationView(style: .stack), on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.navigationView(style: .stack), on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -48,7 +48,7 @@ import SwiftUI
 ///             Text("Root")
 ///         }
 ///         .navigationViewStyle(.stack)
-///         .introspect(.navigationView(style: .stack), on: .visionOS(.v1)) {
+///         .introspect(.navigationView(style: .stack), on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -71,6 +71,7 @@ extension iOSViewVersion<NavigationViewWithStackStyleType, UINavigationControlle
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UINavigationController> {
         .default.withAncestorSelector(\.navigationController)
@@ -83,6 +84,7 @@ extension tvOSViewVersion<NavigationViewWithStackStyleType, UINavigationControll
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UINavigationController> {
         .default.withAncestorSelector(\.navigationController)
@@ -91,6 +93,7 @@ extension tvOSViewVersion<NavigationViewWithStackStyleType, UINavigationControll
 
 extension visionOSViewVersion<NavigationViewWithStackStyleType, UINavigationController> {
     public static let v1 = Self(for: .v1, selector: selector)
+    public static let v2 = Self(for: .v2, selector: selector)
 
     private static var selector: IntrospectionSelector<UINavigationController> {
         .default.withAncestorSelector(\.navigationController)

--- a/Sources/ViewTypes/PageControl.swift
+++ b/Sources/ViewTypes/PageControl.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///             Text("Page 2").frame(maxWidth: .infinity, maxHeight: .infinity).background(Color.blue)
 ///         }
 ///         .tabViewStyle(.page(indexDisplayMode: .always))
-///         .introspect(.pageControl, on: .iOS(.v14, .v15, .v16, .v17)) {
+///         .introspect(.pageControl, on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UIPageControl
 ///         }
 ///     }
@@ -30,7 +30,7 @@ import SwiftUI
 ///             Text("Page 2").frame(maxWidth: .infinity, maxHeight: .infinity).background(Color.blue)
 ///         }
 ///         .tabViewStyle(.page(indexDisplayMode: .always))
-///         .introspect(.pageControl, on: .tvOS(.v14, .v15, .v16, .v17)) {
+///         .introspect(.pageControl, on: .tvOS(.v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UIPageControl
 ///         }
 ///     }
@@ -51,7 +51,7 @@ import SwiftUI
 ///             Text("Page 2").frame(maxWidth: .infinity, maxHeight: .infinity).background(Color.blue)
 ///         }
 ///         .tabViewStyle(.page(indexDisplayMode: .always))
-///         .introspect(.pageControl, on: .visionOS(.v1)) {
+///         .introspect(.pageControl, on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UIPageControl
 ///         }
 ///     }
@@ -71,6 +71,7 @@ extension iOSViewVersion<PageControlType, UIPageControl> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<PageControlType, UIPageControl> {
@@ -80,10 +81,12 @@ extension tvOSViewVersion<PageControlType, UIPageControl> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<PageControlType, UIPageControl> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/PickerWithMenuStyle.swift
+++ b/Sources/ViewTypes/PickerWithMenuStyle.swift
@@ -24,7 +24,7 @@ import SwiftUI
 ///             Text("3").tag("3")
 ///         }
 ///         .pickerStyle(.menu)
-///         .introspect(.picker(style: .menu), on: .macOS(.v11, .v12, .v13, .v14)) {
+///         .introspect(.picker(style: .menu), on: .macOS(.v11, .v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSPopUpButton
 ///         }
 ///     }
@@ -53,6 +53,7 @@ extension macOSViewVersion<PickerWithMenuStyleType, NSPopUpButton> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/PickerWithSegmentedStyle.swift
+++ b/Sources/ViewTypes/PickerWithSegmentedStyle.swift
@@ -16,7 +16,7 @@ import SwiftUI
 ///             Text("3").tag("3")
 ///         }
 ///         .pickerStyle(.segmented)
-///         .introspect(.picker(style: .segmented), on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.picker(style: .segmented), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UISegmentedControl
 ///         }
 ///     }
@@ -36,7 +36,7 @@ import SwiftUI
 ///             Text("3").tag("3")
 ///         }
 ///         .pickerStyle(.segmented)
-///         .introspect(.picker(style: .segmented), on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.picker(style: .segmented), on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UISegmentedControl
 ///         }
 ///     }
@@ -56,7 +56,7 @@ import SwiftUI
 ///             Text("3").tag("3")
 ///         }
 ///         .pickerStyle(.segmented)
-///         .introspect(.picker(style: .segmented), on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///         .introspect(.picker(style: .segmented), on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSSegmentedControl
 ///         }
 ///     }
@@ -76,7 +76,7 @@ import SwiftUI
 ///             Text("3").tag("3")
 ///         }
 ///         .pickerStyle(.segmented)
-///         .introspect(.picker(style: .segmented), on: .visionOS(.v1)) {
+///         .introspect(.picker(style: .segmented), on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UISegmentedControl
 ///         }
 ///     }
@@ -99,6 +99,7 @@ extension iOSViewVersion<PickerWithSegmentedStyleType, UISegmentedControl> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<PickerWithSegmentedStyleType, UISegmentedControl> {
@@ -107,10 +108,12 @@ extension tvOSViewVersion<PickerWithSegmentedStyleType, UISegmentedControl> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<PickerWithSegmentedStyleType, UISegmentedControl> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<PickerWithSegmentedStyleType, NSSegmentedControl> {
@@ -119,6 +122,7 @@ extension macOSViewVersion<PickerWithSegmentedStyleType, NSSegmentedControl> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/PickerWithWheelStyle.swift
+++ b/Sources/ViewTypes/PickerWithWheelStyle.swift
@@ -16,7 +16,7 @@ import SwiftUI
 ///             Text("3").tag("3")
 ///         }
 ///         .pickerStyle(.wheel)
-///         .introspect(.picker(style: .wheel), on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.picker(style: .wheel), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UIPickerView
 ///         }
 ///     }
@@ -44,7 +44,7 @@ import SwiftUI
 ///             Text("3").tag("3")
 ///         }
 ///         .pickerStyle(.wheel)
-///         .introspect(.picker(style: .wheel), on: .visionOS(.v1)) {
+///         .introspect(.picker(style: .wheel), on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UIPickerView
 ///         }
 ///     }
@@ -68,10 +68,12 @@ extension iOSViewVersion<PickerWithWheelStyleType, UIPickerView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<PickerWithWheelStyleType, UIPickerView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/Popover.swift
+++ b/Sources/ViewTypes/Popover.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///         Button("Present", action: { isPresented = true })
 ///             .popover(isPresented: $isPresented) {
 ///                 Button("Dismiss", action: { isPresented = false })
-///                     .introspect(.popover, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///                     .introspect(.popover, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                         print(type(of: $0)) // UIPopoverPresentationController
 ///                     }
 ///             }
@@ -39,7 +39,7 @@ import SwiftUI
 ///         Button("Present", action: { isPresented = true })
 ///             .popover(isPresented: $isPresented) {
 ///                 Button("Dismiss", action: { isPresented = false })
-///                     .introspect(.popover, on: .visionOS(.v1)) {
+///                     .introspect(.popover, on: .visionOS(.v1, .v2)) {
 ///                         print(type(of: $0)) // UIPopoverPresentationController
 ///                     }
 ///             }
@@ -62,6 +62,7 @@ extension iOSViewVersion<PopoverType, UIPopoverPresentationController> {
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UIPopoverPresentationController> {
         .from(UIViewController.self, selector: \.popoverPresentationController)
@@ -70,6 +71,7 @@ extension iOSViewVersion<PopoverType, UIPopoverPresentationController> {
 
 extension visionOSViewVersion<PopoverType, UIPopoverPresentationController> {
     public static let v1 = Self(for: .v1, selector: selector)
+    public static let v2 = Self(for: .v2, selector: selector)
 
     private static var selector: IntrospectionSelector<UIPopoverPresentationController> {
         .from(UIViewController.self, selector: \.popoverPresentationController)

--- a/Sources/ViewTypes/ProgressViewWithCircularStyle.swift
+++ b/Sources/ViewTypes/ProgressViewWithCircularStyle.swift
@@ -10,7 +10,7 @@ import SwiftUI
 ///     var body: some View {
 ///         ProgressView(value: 0.5)
 ///             .progressViewStyle(.circular)
-///             .introspect(.progressView(style: .circular), on: .iOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.progressView(style: .circular), on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIActivityIndicatorView
 ///             }
 ///     }
@@ -24,7 +24,7 @@ import SwiftUI
 ///     var body: some View {
 ///         ProgressView(value: 0.5)
 ///             .progressViewStyle(.circular)
-///             .introspect(.progressView(style: .circular), on: .tvOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.progressView(style: .circular), on: .tvOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIActivityIndicatorView
 ///             }
 ///     }
@@ -38,7 +38,7 @@ import SwiftUI
 ///     var body: some View {
 ///         ProgressView(value: 0.5)
 ///             .progressViewStyle(.circular)
-///             .introspect(.progressView(style: .circular), on: .macOS(.v11, .v12, .v13, .v14)) {
+///             .introspect(.progressView(style: .circular), on: .macOS(.v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSProgressIndicator
 ///             }
 ///     }
@@ -52,7 +52,7 @@ import SwiftUI
 ///     var body: some View {
 ///         ProgressView(value: 0.5)
 ///             .progressViewStyle(.circular)
-///             .introspect(.progressView(style: .circular), on: .visionOS(.v1)) {
+///             .introspect(.progressView(style: .circular), on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UIActivityIndicatorView
 ///             }
 ///     }
@@ -76,6 +76,7 @@ extension iOSViewVersion<ProgressViewWithCircularStyleType, UIActivityIndicatorV
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<ProgressViewWithCircularStyleType, UIActivityIndicatorView> {
@@ -85,10 +86,12 @@ extension tvOSViewVersion<ProgressViewWithCircularStyleType, UIActivityIndicator
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ProgressViewWithCircularStyleType, UIActivityIndicatorView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ProgressViewWithCircularStyleType, NSProgressIndicator> {
@@ -98,6 +101,7 @@ extension macOSViewVersion<ProgressViewWithCircularStyleType, NSProgressIndicato
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ProgressViewWithLinearStyle.swift
+++ b/Sources/ViewTypes/ProgressViewWithLinearStyle.swift
@@ -10,7 +10,7 @@ import SwiftUI
 ///     var body: some View {
 ///         ProgressView(value: 0.5)
 ///             .progressViewStyle(.linear)
-///             .introspect(.progressView(style: .linear), on: .iOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.progressView(style: .linear), on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIProgressView
 ///             }
 ///     }
@@ -24,7 +24,7 @@ import SwiftUI
 ///     var body: some View {
 ///         ProgressView(value: 0.5)
 ///             .progressViewStyle(.linear)
-///             .introspect(.progressView(style: .linear), on: .tvOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.progressView(style: .linear), on: .tvOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIProgressView
 ///             }
 ///     }
@@ -38,7 +38,7 @@ import SwiftUI
 ///     var body: some View {
 ///         ProgressView(value: 0.5)
 ///             .progressViewStyle(.linear)
-///             .introspect(.progressView(style: .linear), on: .macOS(.v11, .v12, .v13, .v14)) {
+///             .introspect(.progressView(style: .linear), on: .macOS(.v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSProgressIndicator
 ///             }
 ///     }
@@ -52,7 +52,7 @@ import SwiftUI
 ///     var body: some View {
 ///         ProgressView(value: 0.5)
 ///             .progressViewStyle(.linear)
-///             .introspect(.progressView(style: .linear), on: .visionOS(.v1)) {
+///             .introspect(.progressView(style: .linear), on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UIProgressView
 ///             }
 ///     }
@@ -76,6 +76,7 @@ extension iOSViewVersion<ProgressViewWithLinearStyleType, UIProgressView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<ProgressViewWithLinearStyleType, UIProgressView> {
@@ -85,10 +86,12 @@ extension tvOSViewVersion<ProgressViewWithLinearStyleType, UIProgressView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ProgressViewWithLinearStyleType, UIProgressView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ProgressViewWithLinearStyleType, NSProgressIndicator> {
@@ -98,6 +101,7 @@ extension macOSViewVersion<ProgressViewWithLinearStyleType, NSProgressIndicator>
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ScrollView.swift
+++ b/Sources/ViewTypes/ScrollView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///         ScrollView {
 ///             Text("Item")
 ///         }
-///         .introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UIScrollView
 ///         }
 ///     }
@@ -26,7 +26,7 @@ import SwiftUI
 ///         ScrollView {
 ///             Text("Item")
 ///         }
-///         .introspect(.scrollView, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.scrollView, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UIScrollView
 ///         }
 ///     }
@@ -41,7 +41,7 @@ import SwiftUI
 ///         ScrollView {
 ///             Text("Item")
 ///         }
-///         .introspect(.scrollView, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///         .introspect(.scrollView, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSScrollView
 ///         }
 ///     }
@@ -56,7 +56,7 @@ import SwiftUI
 ///         ScrollView {
 ///             Text("Item")
 ///         }
-///         .introspect(.scrollView, on: .visionOS(.v1)) {
+///         .introspect(.scrollView, on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UIScrollView
 ///         }
 ///     }
@@ -75,6 +75,7 @@ extension iOSViewVersion<ScrollViewType, UIScrollView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<ScrollViewType, UIScrollView> {
@@ -83,10 +84,12 @@ extension tvOSViewVersion<ScrollViewType, UIScrollView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ScrollViewType, UIScrollView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ScrollViewType, NSScrollView> {
@@ -95,6 +98,7 @@ extension macOSViewVersion<ScrollViewType, NSScrollView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/SearchField.swift
+++ b/Sources/ViewTypes/SearchField.swift
@@ -15,7 +15,7 @@ import SwiftUI
 ///                 .searchable(text: $searchTerm)
 ///         }
 ///         .navigationViewStyle(.stack)
-///         .introspect(.searchField, on: .iOS(.v15, .v16, .v17)) {
+///         .introspect(.searchField, on: .iOS(.v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UISearchBar
 ///         }
 ///     }
@@ -34,7 +34,7 @@ import SwiftUI
 ///                 .searchable(text: $searchTerm)
 ///         }
 ///         .navigationViewStyle(.stack)
-///         .introspect(.searchField, on: .tvOS(.v15, .v16, .v17)) {
+///         .introspect(.searchField, on: .tvOS(.v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UISearchBar
 ///         }
 ///     }
@@ -57,7 +57,7 @@ import SwiftUI
 ///                 .searchable(text: $searchTerm)
 ///         }
 ///         .navigationViewStyle(.stack)
-///         .introspect(.searchField, on: .visionOS(.v1)) {
+///         .introspect(.searchField, on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UISearchBar
 ///         }
 ///     }
@@ -78,6 +78,7 @@ extension iOSViewVersion<SearchFieldType, UISearchBar> {
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UISearchBar> {
         .from(UINavigationController.self) {
@@ -94,6 +95,7 @@ extension tvOSViewVersion<SearchFieldType, UISearchBar> {
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UISearchBar> {
         .from(UINavigationController.self) {
@@ -104,6 +106,7 @@ extension tvOSViewVersion<SearchFieldType, UISearchBar> {
 
 extension visionOSViewVersion<SearchFieldType, UISearchBar> {
     public static let v1 = Self(for: .v1, selector: selector)
+    public static let v2 = Self(for: .v2, selector: selector)
 
     private static var selector: IntrospectionSelector<UISearchBar> {
         .from(UINavigationController.self) {

--- a/Sources/ViewTypes/SecureField.swift
+++ b/Sources/ViewTypes/SecureField.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         SecureField("Secure Field", text: $text)
-///             .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.secureField, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UISecureField
 ///             }
 ///     }
@@ -26,7 +26,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         SecureField("Secure Field", text: $text)
-///             .introspect(.secureField, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.secureField, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UISecureField
 ///             }
 ///     }
@@ -41,7 +41,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         SecureField("Secure Field", text: $text)
-///             .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.secureField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSSecureField
 ///             }
 ///     }
@@ -56,7 +56,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         SecureField("Secure Field", text: $text)
-///             .introspect(.secureField, on: .visionOS(.v1)) {
+///             .introspect(.secureField, on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UISecureField
 ///             }
 ///     }
@@ -75,6 +75,7 @@ extension iOSViewVersion<SecureFieldType, UITextField> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<SecureFieldType, UITextField> {
@@ -83,10 +84,12 @@ extension tvOSViewVersion<SecureFieldType, UITextField> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<SecureFieldType, UITextField> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<SecureFieldType, NSTextField> {
@@ -95,6 +98,7 @@ extension macOSViewVersion<SecureFieldType, NSTextField> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/Sheet.swift
+++ b/Sources/ViewTypes/Sheet.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///         Button("Present", action: { isPresented = true })
 ///             .sheet(isPresented: $isPresented) {
 ///                 Button("Dismiss", action: { isPresented = false })
-///                     .introspect(.sheet, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///                     .introspect(.sheet, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                         print(type(of: $0)) // UIPresentationController
 ///                     }
 ///             }
@@ -31,7 +31,7 @@ import SwiftUI
 ///         Button("Present", action: { isPresented = true })
 ///             .sheet(isPresented: $isPresented) {
 ///                 Button("Dismiss", action: { isPresented = false })
-///                     .introspect(.sheet, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///                     .introspect(.sheet, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                         print(type(of: $0)) // UIPresentationController
 ///                     }
 ///             }
@@ -53,7 +53,7 @@ import SwiftUI
 ///         Button("Present", action: { isPresented = true })
 ///             .sheet(isPresented: $isPresented) {
 ///                 Button("Dismiss", action: { isPresented = false })
-///                     .introspect(.sheet, on: .visionOS(.v1)) {
+///                     .introspect(.sheet, on: .visionOS(.v1, .v2)) {
 ///                         print(type(of: $0)) // UISheetPresentationController
 ///                     }
 ///             }
@@ -76,6 +76,7 @@ extension iOSViewVersion<SheetType, UIPresentationController> {
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UIPresentationController> {
         .from(UIViewController.self, selector: \.presentationController)
@@ -91,6 +92,8 @@ extension iOSViewVersion<SheetType, UISheetPresentationController> {
     public static let v16 = Self(for: .v16, selector: selector)
     @_disfavoredOverload
     public static let v17 = Self(for: .v17, selector: selector)
+    @_disfavoredOverload
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UISheetPresentationController> {
         .from(UIViewController.self, selector: \.sheetPresentationController)
@@ -100,6 +103,7 @@ extension iOSViewVersion<SheetType, UISheetPresentationController> {
 @available(iOS 15, *)
 extension visionOSViewVersion<SheetType, UISheetPresentationController> {
     public static let v1 = Self(for: .v1, selector: selector)
+    public static let v2 = Self(for: .v2, selector: selector)
 
     private static var selector: IntrospectionSelector<UISheetPresentationController> {
         .from(UIViewController.self, selector: \.sheetPresentationController)
@@ -113,6 +117,7 @@ extension tvOSViewVersion<SheetType, UIPresentationController> {
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UIPresentationController> {
         .from(UIViewController.self, selector: \.presentationController)

--- a/Sources/ViewTypes/Slider.swift
+++ b/Sources/ViewTypes/Slider.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         Slider(value: $selection, in: 0...1)
-///             .introspect(.slider, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.slider, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UISlider
 ///             }
 ///     }
@@ -30,7 +30,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         Slider(value: $selection, in: 0...1)
-///             .introspect(.slider, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.slider, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSSlider
 ///             }
 ///     }
@@ -54,6 +54,7 @@ extension iOSViewVersion<SliderType, UISlider> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<SliderType, NSSlider> {
@@ -62,6 +63,7 @@ extension macOSViewVersion<SliderType, NSSlider> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/Stepper.swift
+++ b/Sources/ViewTypes/Stepper.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         Stepper("Select a number", value: $selection, in: 0...10)
-///             .introspect(.stepper, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.stepper, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIStepper
 ///             }
 ///     }
@@ -30,7 +30,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         Stepper("Select a number", value: $selection, in: 0...10)
-///             .introspect(.stepper, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.stepper, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSStepper
 ///             }
 ///     }
@@ -54,6 +54,7 @@ extension iOSViewVersion<StepperType, UIStepper> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<StepperType, NSStepper> {
@@ -62,6 +63,7 @@ extension macOSViewVersion<StepperType, NSStepper> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/TabView.swift
+++ b/Sources/ViewTypes/TabView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///             Text("Tab 1").tabItem { Text("Tab 1") }
 ///             Text("Tab 2").tabItem { Text("Tab 2") }
 ///         }
-///         .introspect(.tabView, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.tabView, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UITabBarController
 ///         }
 ///     }
@@ -28,7 +28,7 @@ import SwiftUI
 ///             Text("Tab 1").tabItem { Text("Tab 1") }
 ///             Text("Tab 2").tabItem { Text("Tab 2") }
 ///         }
-///         .introspect(.tabView, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.tabView, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UITabBarController
 ///         }
 ///     }
@@ -44,7 +44,7 @@ import SwiftUI
 ///             Text("Tab 1").tabItem { Text("Tab 1") }
 ///             Text("Tab 2").tabItem { Text("Tab 2") }
 ///         }
-///         .introspect(.tabView, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///         .introspect(.tabView, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSTabView
 ///         }
 ///     }
@@ -68,6 +68,7 @@ extension iOSViewVersion<TabViewType, UITabBarController> {
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UITabBarController> {
         .default.withAncestorSelector(\.tabBarController)
@@ -80,6 +81,7 @@ extension tvOSViewVersion<TabViewType, UITabBarController> {
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UITabBarController> {
         .default.withAncestorSelector(\.tabBarController)
@@ -92,6 +94,7 @@ extension macOSViewVersion<TabViewType, NSTabView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/TabViewWithPageStyle.swift
+++ b/Sources/ViewTypes/TabViewWithPageStyle.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///             Text("Page 2").frame(maxWidth: .infinity, maxHeight: .infinity).background(Color.blue)
 ///         }
 ///         .tabViewStyle(.page(indexDisplayMode: .always))
-///         .introspect(.tabView(style: .page), on: .iOS(.v14, .v15, .v16, .v17)) {
+///         .introspect(.tabView(style: .page), on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -30,7 +30,7 @@ import SwiftUI
 ///             Text("Page 2").frame(maxWidth: .infinity, maxHeight: .infinity).background(Color.blue)
 ///         }
 ///         .tabViewStyle(.page(indexDisplayMode: .always))
-///         .introspect(.tabView(style: .page), on: .tvOS(.v14, .v15, .v16, .v17)) {
+///         .introspect(.tabView(style: .page), on: .tvOS(.v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -51,7 +51,7 @@ import SwiftUI
 ///             Text("Page 2").frame(maxWidth: .infinity, maxHeight: .infinity).background(Color.blue)
 ///         }
 ///         .tabViewStyle(.page(indexDisplayMode: .always))
-///         .introspect(.tabView(style: .page), on: .visionOS(.v1)) {
+///         .introspect(.tabView(style: .page), on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -76,6 +76,7 @@ extension iOSViewVersion<TabViewWithPageStyleType, UICollectionView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<TabViewWithPageStyleType, UICollectionView> {
@@ -85,10 +86,12 @@ extension tvOSViewVersion<TabViewWithPageStyleType, UICollectionView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<TabViewWithPageStyleType, UICollectionView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/Table.swift
+++ b/Sources/ViewTypes/Table.swift
@@ -28,7 +28,7 @@ import SwiftUI
 ///             TableRow(Purchase(price: 50))
 ///             TableRow(Purchase(price: 75))
 ///         }
-///         .introspect(.table, on: .iOS(.v16, .v17)) {
+///         .introspect(.table, on: .iOS(.v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -64,7 +64,7 @@ import SwiftUI
 ///             TableRow(Purchase(price: 50))
 ///             TableRow(Purchase(price: 75))
 ///         }
-///         .introspect(.table, on: .macOS(.v12, .v13, .v14)) {
+///         .introspect(.table, on: .macOS(.v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // NSTableView
 ///         }
 ///     }
@@ -96,7 +96,7 @@ import SwiftUI
 ///             TableRow(Purchase(price: 50))
 ///             TableRow(Purchase(price: 75))
 ///         }
-///         .introspect(.table, on: .visionOS(.v1)) {
+///         .introspect(.table, on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UICollectionView
 ///         }
 ///     }
@@ -119,10 +119,12 @@ extension iOSViewVersion<TableType, UICollectionView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<TableType, UICollectionView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<TableType, NSTableView> {
@@ -133,6 +135,7 @@ extension macOSViewVersion<TableType, NSTableView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/TextEditor.swift
+++ b/Sources/ViewTypes/TextEditor.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextEditor(text: $text)
-///             .introspect(.textEditor, on: .iOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.textEditor, on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UITextView
 ///             }
 ///     }
@@ -30,7 +30,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextEditor(text: $text)
-///             .introspect(.textEditor, on: .macOS(.v11, .v12, .v13, .v14)) {
+///             .introspect(.textEditor, on: .macOS(.v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSTextView
 ///             }
 ///     }
@@ -45,7 +45,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextEditor(text: $text)
-///             .introspect(.textEditor, on: .visionOS(.v1)) {
+///             .introspect(.textEditor, on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UITextView
 ///             }
 ///     }
@@ -66,10 +66,12 @@ extension iOSViewVersion<TextEditorType, UITextView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<TextEditorType, UITextView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<TextEditorType, NSTextView> {
@@ -79,6 +81,7 @@ extension macOSViewVersion<TextEditorType, NSTextView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/TextField.swift
+++ b/Sources/ViewTypes/TextField.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextField("Text Field", text: $text)
-///             .introspect(.textField, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.textField, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UITextField
 ///             }
 ///     }
@@ -26,7 +26,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextField("Text Field", text: $text)
-///             .introspect(.textField, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.textField, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UITextField
 ///             }
 ///     }
@@ -41,7 +41,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextField("Text Field", text: $text)
-///             .introspect(.textField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.textField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSTextField
 ///             }
 ///     }
@@ -56,7 +56,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextField("Text Field", text: $text)
-///             .introspect(.textField, on: .visionOS(.v1)) {
+///             .introspect(.textField, on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UITextField
 ///             }
 ///     }
@@ -75,6 +75,7 @@ extension iOSViewVersion<TextFieldType, UITextField> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<TextFieldType, UITextField> {
@@ -83,10 +84,12 @@ extension tvOSViewVersion<TextFieldType, UITextField> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<TextFieldType, UITextField> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<TextFieldType, NSTextField> {
@@ -95,6 +98,7 @@ extension macOSViewVersion<TextFieldType, NSTextField> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/TextFieldWithVerticalAxis.swift
+++ b/Sources/ViewTypes/TextFieldWithVerticalAxis.swift
@@ -97,6 +97,7 @@ extension tvOSViewVersion<TextFieldWithVerticalAxisType, UITextField> {
     public static let v15 = Self.unavailable()
 
     public static let v16 = Self(for: .v16)
+    public static let v17 = Self(for: .v17)
     public static let v18 = Self(for: .v18)
 }
 

--- a/Sources/ViewTypes/TextFieldWithVerticalAxis.swift
+++ b/Sources/ViewTypes/TextFieldWithVerticalAxis.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextField("Text Field", text: $text, axis: .vertical)
-///             .introspect(.textField(axis: .vertical), on: .iOS(.v16, .v17)) {
+///             .introspect(.textField(axis: .vertical), on: .iOS(.v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UITextView
 ///             }
 ///     }
@@ -26,7 +26,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextField("Text Field", text: $text, axis: .vertical)
-///             .introspect(.textField(axis: .vertical), on: .tvOS(.v16, .v17)) {
+///             .introspect(.textField(axis: .vertical), on: .tvOS(.v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UITextField
 ///             }
 ///     }
@@ -41,7 +41,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextField("Text Field", text: $text, axis: .vertical)
-///             .introspect(.textField(axis: .vertical), on: .macOS(.v13, .v14)) {
+///             .introspect(.textField(axis: .vertical), on: .macOS(.v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSTextField
 ///             }
 ///     }
@@ -56,7 +56,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         TextField("Text Field", text: $text, axis: .vertical)
-///             .introspect(.textField(axis: .vertical), on: .visionOS(.v1)) {
+///             .introspect(.textField(axis: .vertical), on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UITextView
 ///             }
 ///     }
@@ -85,6 +85,7 @@ extension iOSViewVersion<TextFieldWithVerticalAxisType, UITextView> {
 
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<TextFieldWithVerticalAxisType, UITextField> {
@@ -96,11 +97,12 @@ extension tvOSViewVersion<TextFieldWithVerticalAxisType, UITextField> {
     public static let v15 = Self.unavailable()
 
     public static let v16 = Self(for: .v16)
-    public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<TextFieldWithVerticalAxisType, UITextView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<TextFieldWithVerticalAxisType, NSTextField> {
@@ -113,6 +115,7 @@ extension macOSViewVersion<TextFieldWithVerticalAxisType, NSTextField> {
 
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/Toggle.swift
+++ b/Sources/ViewTypes/Toggle.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         Toggle("Toggle", isOn: $isOn)
-///             .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.toggle, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UISwitch
 ///             }
 ///     }
@@ -30,7 +30,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         Toggle("Toggle", isOn: $isOn)
-///             .introspect(.toggle, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.toggle, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSButton
 ///             }
 ///     }
@@ -54,6 +54,7 @@ extension iOSViewVersion<ToggleType, UISwitch> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ToggleType, NSButton> {
@@ -62,6 +63,7 @@ extension macOSViewVersion<ToggleType, NSButton> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ToggleWithButtonStyle.swift
+++ b/Sources/ViewTypes/ToggleWithButtonStyle.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///     var body: some View {
 ///         Toggle("Toggle", isOn: $isOn)
 ///             .toggleStyle(.button)
-///             .introspect(.toggle(style: .button), on: .macOS(.v12, .v13, .v14)) {
+///             .introspect(.toggle(style: .button), on: .macOS(.v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSButton
 ///             }
 ///     }
@@ -50,6 +50,7 @@ extension macOSViewVersion<ToggleWithButtonStyleType, NSButton> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ToggleWithCheckboxStyle.swift
+++ b/Sources/ViewTypes/ToggleWithCheckboxStyle.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///     var body: some View {
 ///         Toggle("Checkbox", isOn: $isOn)
 ///             .toggleStyle(.checkbox)
-///             .introspect(.toggle(style: .checkbox), on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.toggle(style: .checkbox), on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSButton
 ///             }
 ///     }
@@ -48,6 +48,7 @@ extension macOSViewVersion<ToggleWithCheckboxStyleType, NSButton> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ToggleWithSwitchStyle.swift
+++ b/Sources/ViewTypes/ToggleWithSwitchStyle.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///     var body: some View {
 ///         Toggle("Switch", isOn: $isOn)
 ///             .toggleStyle(.switch)
-///             .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.toggle(style: .switch), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UISwitch
 ///             }
 ///     }
@@ -32,7 +32,7 @@ import SwiftUI
 ///     var body: some View {
 ///         Toggle("Switch", isOn: $isOn)
 ///             .toggleStyle(.switch)
-///             .introspect(.toggle(style: .switch), on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.toggle(style: .switch), on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSSwitch
 ///             }
 ///     }
@@ -60,6 +60,7 @@ extension iOSViewVersion<ToggleWithSwitchStyleType, UISwitch> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ToggleWithSwitchStyleType, NSSwitch> {
@@ -68,6 +69,7 @@ extension macOSViewVersion<ToggleWithSwitchStyleType, NSSwitch> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/VideoPlayer.swift
+++ b/Sources/ViewTypes/VideoPlayer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// struct ContentView: View {
 ///     var body: some View {
 ///         VideoPlayer(player: AVPlayer(url: URL(string: "https://bit.ly/swswift")!))
-///             .introspect(.videoPlayer, on: .iOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.videoPlayer, on: .iOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // AVPlayerViewController
 ///             }
 ///     }
@@ -22,7 +22,7 @@ import SwiftUI
 /// struct ContentView: View {
 ///     var body: some View {
 ///         VideoPlayer(player: AVPlayer(url: URL(string: "https://bit.ly/swswift")!))
-///             .introspect(.videoPlayer, on: .tvOS(.v14, .v15, .v16, .v17)) {
+///             .introspect(.videoPlayer, on: .tvOS(.v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // AVPlayerViewController
 ///             }
 ///     }
@@ -35,7 +35,7 @@ import SwiftUI
 /// struct ContentView: View {
 ///     var body: some View {
 ///         VideoPlayer(player: AVPlayer(url: URL(string: "https://bit.ly/swswift")!))
-///             .introspect(.videoPlayer, on: .macOS(.v11, .v12, .v13, .v14)) {
+///             .introspect(.videoPlayer, on: .macOS(.v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // AVPlayerView
 ///             }
 ///     }
@@ -48,7 +48,7 @@ import SwiftUI
 /// struct ContentView: View {
 ///     var body: some View {
 ///         VideoPlayer(player: AVPlayer(url: URL(string: "https://bit.ly/swswift")!))
-///             .introspect(.videoPlayer, on: .visionOS(.v1)) {
+///             .introspect(.videoPlayer, on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // AVPlayerViewController
 ///             }
 ///     }
@@ -71,6 +71,7 @@ extension iOSViewVersion<VideoPlayerType, AVPlayerViewController> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<VideoPlayerType, AVPlayerViewController> {
@@ -80,10 +81,12 @@ extension tvOSViewVersion<VideoPlayerType, AVPlayerViewController> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<VideoPlayerType, AVPlayerViewController> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<VideoPlayerType, AVPlayerView> {
@@ -93,6 +96,7 @@ extension macOSViewVersion<VideoPlayerType, AVPlayerView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/View.swift
+++ b/Sources/ViewTypes/View.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///             Image(systemName: "scribble")
 ///             Text("Some text")
 ///         }
-///         .introspect(.view, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.view, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // some subclass of UIView
 ///         }
 ///     }
@@ -28,7 +28,7 @@ import SwiftUI
 ///             Image(systemName: "scribble")
 ///             Text("Some text")
 ///         }
-///         .introspect(.view, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.view, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // some subclass of UIView
 ///         }
 ///     }
@@ -44,7 +44,7 @@ import SwiftUI
 ///             Image(systemName: "scribble")
 ///             Text("Some text")
 ///         }
-///         .introspect(.view, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///         .introspect(.view, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///             print(type(of: $0)) // some subclass of NSView
 ///         }
 ///     }
@@ -60,7 +60,7 @@ import SwiftUI
 ///             Image(systemName: "scribble")
 ///             Text("Some text")
 ///         }
-///         .introspect(.view, on: .visionOS(.v1)) {
+///         .introspect(.view, on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // some subclass of UIView
 ///         }
 ///     }
@@ -79,6 +79,7 @@ extension iOSViewVersion<ViewType, UIView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<ViewType, UIView> {
@@ -87,10 +88,12 @@ extension tvOSViewVersion<ViewType, UIView> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ViewType, UIView> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #elseif canImport(AppKit)
 extension macOSViewVersion<ViewType, NSView> {
@@ -99,6 +102,7 @@ extension macOSViewVersion<ViewType, NSView> {
     public static let v12 = Self(for: .v12)
     public static let v13 = Self(for: .v13)
     public static let v14 = Self(for: .v14)
+    public static let v15 = Self(for: .v15)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/ViewController.swift
+++ b/Sources/ViewTypes/ViewController.swift
@@ -11,12 +11,12 @@ import SwiftUI
 ///     var body: some View {
 ///         NavigationView {
 ///             Text("Root").frame(maxWidth: .infinity, maxHeight: .infinity).background(Color.red)
-///                 .introspect(.viewController, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///                 .introspect(.viewController, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                     print(type(of: $0)) // some subclass of UIHostingController
 ///                 }
 ///         }
 ///         .navigationViewStyle(.stack)
-///         .introspect(.viewController, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.viewController, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -30,12 +30,12 @@ import SwiftUI
 ///     var body: some View {
 ///         NavigationView {
 ///             Text("Root").frame(maxWidth: .infinity, maxHeight: .infinity).background(Color.red)
-///                 .introspect(.viewController, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///                 .introspect(.viewController, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                     print(type(of: $0)) // some subclass of UIHostingController
 ///                 }
 ///         }
 ///         .navigationViewStyle(.stack)
-///         .introspect(.viewController, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///         .introspect(.viewController, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -53,12 +53,12 @@ import SwiftUI
 ///     var body: some View {
 ///         NavigationView {
 ///             Text("Root").frame(maxWidth: .infinity, maxHeight: .infinity).background(Color.red)
-///                 .introspect(.viewController, on: .visionOS(.v1)) {
+///                 .introspect(.viewController, on: .visionOS(.v1, .v2)) {
 ///                     print(type(of: $0)) // some subclass of UIHostingController
 ///                 }
 ///         }
 ///         .navigationViewStyle(.stack)
-///         .introspect(.viewController, on: .visionOS(.v1)) {
+///         .introspect(.viewController, on: .visionOS(.v1, .v2)) {
 ///             print(type(of: $0)) // UINavigationController
 ///         }
 ///     }
@@ -79,6 +79,7 @@ extension iOSViewVersion<ViewControllerType, UIViewController> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension tvOSViewVersion<ViewControllerType, UIViewController> {
@@ -87,10 +88,12 @@ extension tvOSViewVersion<ViewControllerType, UIViewController> {
     public static let v15 = Self(for: .v15)
     public static let v16 = Self(for: .v16)
     public static let v17 = Self(for: .v17)
+    public static let v18 = Self(for: .v18)
 }
 
 extension visionOSViewVersion<ViewControllerType, UIViewController> {
     public static let v1 = Self(for: .v1)
+    public static let v2 = Self(for: .v2)
 }
 #endif
 #endif

--- a/Sources/ViewTypes/Window.swift
+++ b/Sources/ViewTypes/Window.swift
@@ -79,6 +79,7 @@ extension tvOSViewVersion<WindowType, UIWindow> {
     public static let v14 = Self(for: .v14, selector: selector)
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
+    public static let v17 = Self(for: .v17, selector: selector)
     public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UIWindow> {

--- a/Sources/ViewTypes/Window.swift
+++ b/Sources/ViewTypes/Window.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// struct ContentView: View {
 ///     var body: some View {
 ///         Text("Content")
-///             .introspect(.window, on: .iOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.window, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIWindow
 ///             }
 ///     }
@@ -22,7 +22,7 @@ import SwiftUI
 /// struct ContentView: View {
 ///     var body: some View {
 ///         Text("Content")
-///             .introspect(.window, on: .tvOS(.v13, .v14, .v15, .v16, .v17)) {
+///             .introspect(.window, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18)) {
 ///                 print(type(of: $0)) // UIWindow
 ///             }
 ///     }
@@ -35,7 +35,7 @@ import SwiftUI
 /// struct ContentView: View {
 ///     var body: some View {
 ///         Text("Content")
-///             .introspect(.window, on: .macOS(.v10_15, .v11, .v12, .v13, .v14)) {
+///             .introspect(.window, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSWindow
 ///             }
 ///     }
@@ -48,7 +48,7 @@ import SwiftUI
 /// struct ContentView: View {
 ///     var body: some View {
 ///         Text("Content")
-///             .introspect(.window, on: .visionOS(.v1)) {
+///             .introspect(.window, on: .visionOS(.v1, .v2)) {
 ///                 print(type(of: $0)) // UIWindow
 ///             }
 ///     }
@@ -67,6 +67,7 @@ extension iOSViewVersion<WindowType, UIWindow> {
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
     public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UIWindow> {
         .from(UIView.self, selector: \.window)
@@ -78,7 +79,7 @@ extension tvOSViewVersion<WindowType, UIWindow> {
     public static let v14 = Self(for: .v14, selector: selector)
     public static let v15 = Self(for: .v15, selector: selector)
     public static let v16 = Self(for: .v16, selector: selector)
-    public static let v17 = Self(for: .v17, selector: selector)
+    public static let v18 = Self(for: .v18, selector: selector)
 
     private static var selector: IntrospectionSelector<UIWindow> {
         .from(UIView.self, selector: \.window)
@@ -87,6 +88,7 @@ extension tvOSViewVersion<WindowType, UIWindow> {
 
 extension visionOSViewVersion<WindowType, UIWindow> {
     public static let v1 = Self(for: .v1, selector: selector)
+    public static let v2 = Self(for: .v2, selector: selector)
 
     private static var selector: IntrospectionSelector<UIWindow> {
         .from(UIView.self, selector: \.window)
@@ -99,6 +101,7 @@ extension macOSViewVersion<WindowType, NSWindow> {
     public static let v12 = Self(for: .v12, selector: selector)
     public static let v13 = Self(for: .v13, selector: selector)
     public static let v14 = Self(for: .v14, selector: selector)
+    public static let v15 = Self(for: .v15, selector: selector)
 
     private static var selector: IntrospectionSelector<NSWindow> {
         .from(NSView.self, selector: \.window)


### PR DESCRIPTION
This PR adds new iOS, tvOS, macOS, and visionOS platform versions to support the new versions of the said OSes, announced at WWDC24.

Closes: #419 