### PR TITLE
Infra: disable CD and add manual CocoaPods release script

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,8 +7,9 @@ on:
 
 jobs:
   deploy:
+    if: false
     name: Deploy to CocoaPods Trunk
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -21,7 +22,7 @@ jobs:
           +: pod xcodes
 
       - name: Select Xcode version
-        run: sudo xcodes select 15.4
+        run: sudo xcodes select 16.4
 
       - name: Deploy to CocoaPods Trunk
         run: |

--- a/script/pod_release
+++ b/script/pod_release
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+
+echo "Publishing version $LIB_VERSION"
+pod trunk push SwiftUIIntrospect.podspec --allow-warnings


### PR DESCRIPTION
Tired of the CocoaPods key expiring and not being able to change it as I don't have the required permissions so I'm just switching to manual releases.