### PR TITLE
Thread hop to ensure 2026 platform compatibility

### DIFF
--- a/Sources/Introspect.swift
+++ b/Sources/Introspect.swift
@@ -26,6 +26,14 @@ extension View {
     ///   - scope: Optionally overrides the view's default scope of introspection.
     ///   - customize: A closure that hands over the underlying UIKit/AppKit instance ready for customization.
     ///
+    ///     Note there is no guarantee of one-time execution for this closure. As `customize` may fire multiple times,
+    ///     make sure to guard against repeated or heavy work in your closure by keeping track of its completeness.
+    ///
+    ///     Additionally, note mutating SwiftUI state within `customize` will trigger runtime warnings unless that mutation
+    ///     is wrapped in a `DispatchQueue.main.async { ... }` call. This is because introspect attempts to hand you
+    ///     the requested view as soon as possible, and this might mean SwiftUI isn't ready for state mutations at that
+    ///     particular moment.
+    ///
     /// Here's an example usage:
     ///
     /// ```swift

--- a/Sources/IntrospectionView.swift
+++ b/Sources/IntrospectionView.swift
@@ -151,7 +151,7 @@ final class IntrospectionPlatformViewController: PlatformViewController {
                 return
             }
 
-            // NB: .introspect makes no guarantees about the number of times it's callback is invoked, so the below is fair play to maximize compatibility and predictability
+            // NB: .introspect makes no guarantees about the number of times its callback is invoked, so the below is fair play to maximize compatibility and predictability
             handler?(self) // we call this eagerly as most customization can successfully happen without a thread hop
             DispatchQueue.main.async {
                 handler?(self) // we also thread hop to cover the rest of the cases where the underlying UI component isn't quite ready for customization

--- a/Sources/IntrospectionView.swift
+++ b/Sources/IntrospectionView.swift
@@ -151,7 +151,8 @@ final class IntrospectionPlatformViewController: PlatformViewController {
                 return
             }
 
-            // NB: .introspect makes no guarantees about the number of times its callback is invoked, so the below is fair play to maximize compatibility and predictability
+            // NB: .introspect makes no guarantees about the number of times its callback is invoked,
+            // so the below is fair play to maximize compatibility and predictability
             handler?(self) // we call this eagerly as most customization can successfully happen without a thread hop
             DispatchQueue.main.async {
                 handler?(self) // we also thread hop to cover the rest of the cases where the underlying UI component isn't quite ready for customization


### PR DESCRIPTION
Something in the way SwiftUI works in xOS 26 makes it so that some views aren't quite ready to be customized by the time they're handed over via the `customize` closure. In this instance, a thread hop is necessary. While we already had a similar mechanism for some iOS 13 scenarios, they were guarded behind `#available`, but now that it's more generalized it makes sense to do it always. I've added a disclaimer to `.introspect` explaining this caveat.

Fixes #465.