### PR TITLE
Mark unavailable macOS 26 introspections

### DIFF
--- a/Sources/ViewTypes/Button.swift
+++ b/Sources/ViewTypes/Button.swift
@@ -9,15 +9,60 @@
 ///
 /// Not available.
 ///
-/// ### macOS
+/// ### macOS 10.15 – 15
 ///
 /// ```swift
 /// struct ContentView: View {
 ///     var body: some View {
-///         Button("Action", action: {})
-///             .introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15, .v26)) {
-///                 print(type(of: $0)) // NSButton
-///             }
+///         VStack {
+///             Button("Plain Button", action: {})
+///                 .introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
+///                     print(type(of: $0)) // NSButton
+///                 }
+///
+///             Button("Bordered Button", action: {})
+///                 .buttonStyle(.bordered)
+///                 .introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
+///                     print(type(of: $0)) // NSButton
+///                 }
+///
+///             Button("Borderless Button", action: {})
+///                 .buttonStyle(.borderless)
+///                 .introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
+///                     print(type(of: $0)) // NSButton
+///                 }
+///
+///             Button("Link Button", action: {})
+///                 .buttonStyle(.link)
+///                 .introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15)) {
+///                     print(type(of: $0)) // NSButton
+///                 }
+///         }
+///     }
+/// }
+/// ```
+///
+/// ### macOS 26
+///
+/// On macOS 26, only the `.borderless` and `.link` button styles are supported for introspection.
+/// Other styles (e.g., plain or bordered) are not supported on macOS 26.
+///
+/// ```swift
+/// struct ContentView: View {
+///     var body: some View {
+///         VStack {
+///             Button("Borderless Button", action: {})
+///                 .buttonStyle(.borderless)
+///                 .introspect(.button, on: .macOS(.v26)) {
+///                     print(type(of: $0)) // NSButton
+///                 }
+///
+///             Button("Link Button", action: {})
+///                 .buttonStyle(.link)
+///                 .introspect(.button, on: .macOS(.v26)) {
+///                     print(type(of: $0)) // NSButton
+///                 }
+///         }
 ///     }
 /// }
 /// ```

--- a/Sources/ViewTypes/ToggleWithButtonStyle.swift
+++ b/Sources/ViewTypes/ToggleWithButtonStyle.swift
@@ -11,8 +11,8 @@
 ///
 /// ### macOS 10.15 - 15
 ///
-/// Note: toggles with button style on macOS 26+ and later no longer use `NSButton` under the hood, so introspection
-/// is not possible.
+/// Note: On macOS 26 and later, toggles with button style are no longer backed by `NSButton`, so introspection is
+/// not possible.
 ///
 /// ```swift
 /// struct ContentView: View {

--- a/Sources/ViewTypes/ToggleWithButtonStyle.swift
+++ b/Sources/ViewTypes/ToggleWithButtonStyle.swift
@@ -9,7 +9,10 @@
 ///
 /// Not available.
 ///
-/// ### macOS
+/// ### macOS 10.15 - 15
+///
+/// Note: toggles with button style on macOS 26+ and later no longer use `NSButton` under the hood, so introspection
+/// is not possible.
 ///
 /// ```swift
 /// struct ContentView: View {
@@ -18,7 +21,7 @@
 ///     var body: some View {
 ///         Toggle("Toggle", isOn: $isOn)
 ///             .toggleStyle(.button)
-///             .introspect(.toggle(style: .button), on: .macOS(.v12, .v13, .v14, .v15, .v26)) {
+///             .introspect(.toggle(style: .button), on: .macOS(.v12, .v13, .v14, .v15)) {
 ///                 print(type(of: $0)) // NSButton
 ///             }
 ///     }
@@ -51,7 +54,8 @@ extension macOSViewVersion<ToggleWithButtonStyleType, NSButton> {
 	public static let v13 = Self(for: .v13)
 	public static let v14 = Self(for: .v14)
 	public static let v15 = Self(for: .v15)
-	public static let v26 = Self(for: .v26)
+	@available(*, unavailable, message: ".toggleStyle(.button) isn't available on macOS 26")
+	public static let v26 = Self.unavailable
 }
 #endif
 #endif

--- a/Tests/Tests/ViewTypes/ButtonTests.swift
+++ b/Tests/Tests/ViewTypes/ButtonTests.swift
@@ -10,36 +10,43 @@ struct ButtonTests {
 	typealias PlatformButton = NSButton
 	#endif
 
-	@Test func introspect() async throws {
+	@available(macOS, introduced: 10.15, obsoleted: 26.0)
+	@Test func introspectButtonsBeforeMacOS26() async throws {
 		let (entity1, entity2, entity3, entity4) = try await introspection(of: PlatformButton.self) { spy1, spy2, spy3, spy4 in
 			VStack {
-				Button("Button 0", action: {})
+				Button("Plain Button", action: {})
+					.introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15), customize: spy1)
+
+				Button("Bordered Button", action: {})
 					.buttonStyle(.bordered)
-					#if os(macOS)
-					.introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15, .v26), customize: spy1)
-					#endif
+					.introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15), customize: spy2)
 
-				Button("Button 1", action: {})
+				Button("Borderless Button", action: {})
 					.buttonStyle(.borderless)
-					#if os(macOS)
-					.introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15, .v26), customize: spy2)
-					#endif
+					.introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15), customize: spy3)
 
-				Button("Button 2", action: {})
+				Button("Link Button", action: {})
 					.buttonStyle(.link)
-					#if os(macOS)
-					.introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15, .v26), customize: spy3)
-					#endif
-
-				Button("Button 3", action: {})
-					#if os(macOS)
-					.introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15, .v26), customize: spy4)
-					#endif
+					.introspect(.button, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15), customize: spy4)
 			}
 		}
-		#if canImport(AppKit)
 		#expect(Set([entity1, entity2, entity3, entity4].map(ObjectIdentifier.init)).count == 4)
-		#endif
+	}
+
+	@available(macOS 26, *)
+	@Test func introspectButtonsOnMacOS26() async throws {
+		let (entity1, entity2) = try await introspection(of: NSButton.self) { spy1, spy2 in
+			VStack {
+				Button("Borderless Button", action: {})
+					.buttonStyle(.borderless)
+					.introspect(.button, on: .macOS(.v26), customize: spy1)
+
+				Button("Link Button", action: {})
+					.buttonStyle(.link)
+					.introspect(.button, on: .macOS(.v26), customize: spy2)
+			}
+		}
+		#expect(Set([entity1, entity2].map(ObjectIdentifier.init)).count == 2)
 	}
 }
 #endif

--- a/Tests/Tests/ViewTypes/ToggleWithButtonStyleTests.swift
+++ b/Tests/Tests/ViewTypes/ToggleWithButtonStyleTests.swift
@@ -6,38 +6,28 @@ import Testing
 @MainActor
 @Suite
 struct ToggleWithButtonStyleTests {
-	#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 	typealias PlatformToggleWithButtonStyle = NSButton
-	#endif
 
-	@available(macOS 12, *)
+	@available(macOS, introduced: 12, obsoleted: 26)
 	@Test func introspect() async throws {
 		let (entity1, entity2, entity3) = try await introspection(of: PlatformToggleWithButtonStyle.self) { spy1, spy2, spy3 in
 			VStack {
 				Toggle("", isOn: .constant(true))
 					.toggleStyle(.button)
-					#if os(macOS)
-					.introspect(.toggle(style: .button), on: .macOS(.v12, .v13, .v14, .v15, .v26), customize: spy1)
-					#endif
-
+					.introspect(.toggle(style: .button), on: .macOS(.v12, .v13, .v14, .v15), customize: spy1)
+				
 				Toggle("", isOn: .constant(false))
 					.toggleStyle(.button)
-					#if os(macOS)
-					.introspect(.toggle(style: .button), on: .macOS(.v12, .v13, .v14, .v15, .v26), customize: spy2)
-					#endif
-
+					.introspect(.toggle(style: .button), on: .macOS(.v12, .v13, .v14, .v15), customize: spy2)
+				
 				Toggle("", isOn: .constant(true))
 					.toggleStyle(.button)
-					#if os(macOS)
-					.introspect(.toggle(style: .button), on: .macOS(.v12, .v13, .v14, .v15, .v26), customize: spy3)
-					#endif
+					.introspect(.toggle(style: .button), on: .macOS(.v12, .v13, .v14, .v15), customize: spy3)
 			}
 		}
-		#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 		#expect(entity1.state == .on)
 		#expect(entity2.state == .off)
 		#expect(entity3.state == .on)
-		#endif
 	}
 }
 #endif


### PR DESCRIPTION
I just installed macOS 26 and there seems to be a couple things no longer introspectable on macOS 26 so here's the PR to reflect that before tagging the official v26 release.