### PR TITLE
Improve README documentation clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,20 @@ ScrollView {
 2. Traverse through all subviews between both marker views until a `UIScrollView` instance (if any) is found.
 
 > [!IMPORTANT]
-> Although this method is solid and unlikely to break on its own, future OS releases require explicit opt in for introspection (`.iOS(.vXYZ)`) because underlying UIKit/AppKit types can change between major versions.
+> Although this method is solid and unlikely to break on its own, future OS releases require explicit opt-in for introspection (`.iOS(.vXYZ)`) because underlying UIKit/AppKit types can change between major versions.
 
-By default, `.introspect` acts on its receiver. Calling `.introspect` from inside the view you want to introspect has no effect. If you need to introspect an ancestor instead, set `scope: .ancestor`:
+> [!NOTE]
+> Version `.v26` represents Apple's unified versioning system introduced in 2025, where iOS, macOS, tvOS, and visionOS all align to version 26. This explains the version jump from `.v18` to `.v26` in the examples.
+
+By default, `.introspect` acts on its receiver. Calling `.introspect` from inside the view you want to introspect has no effect.
+
+**When to use `scope: .ancestor`:** If you need to introspect an ancestor view from within its child, set `scope: .ancestor`:
 
 ```swift
 ScrollView {
 	Text("Item 1")
 		.introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26), scope: .ancestor) { scrollView in
-			// do something with UIScrollView
+			// This introspects the parent ScrollView, not the Text view
 		}
 }
 ```
@@ -343,13 +348,15 @@ struct ContentView: View {
 Note for library authors
 ------------------------
 
-If your library depends on SwiftUI Introspect, declare a version range that spans at least the **last two major versions** instead of jumping straight to the latest. This avoids conflicts when apps pull the library directly and through multiple dependencies. For example:
+If your library depends on SwiftUI Introspect, declare a version range that spans at least the **last two major versions** instead of jumping straight to the latest. This avoids conflicts when apps pull the library directly and through multiple dependencies.
+
+For example, if the current version is 26.0.0:
 
 ```swift
-.package(url: "https://github.com/siteline/swiftui-introspect", "1.3.0"..<"27.0.0"),
+.package(url: "https://github.com/siteline/swiftui-introspect", "25.0.0"..<"27.0.0"),
 ```
 
-A wider range is safe because SwiftUI Introspect is essentially “finished”: no new features will be added, only newer platform versions and view types. Thanks to [`@_spi(Advanced)` imports](https://github.com/siteline/swiftui-introspect#introspect-on-future-platform-versions), it is already future proof without frequent version bumps.
+A wider range is safe because SwiftUI Introspect is essentially "finished": no new features will be added, only newer platform versions and view types. Thanks to [`@_spi(Advanced)` imports](https://github.com/siteline/swiftui-introspect#introspect-on-future-platform-versions), it is already future-proof without frequent version bumps.
 
 Community projects
 ------------------


### PR DESCRIPTION
## Summary

This PR improves the README documentation to address potential confusion and enhance clarity for developers:

- **Explains v26 versioning**: Adds a note explaining Apple's unified versioning system (v26) to prevent confusion about the version jump from v18 to v26
- **Clarifies `scope: .ancestor`**: Adds clearer explanation and inline comment for when/why to use the ancestor scope parameter
- **Updates library author guidance**: Modernizes the version range example to be more current (25.0.0..<27.0.0 instead of 1.3.0..<27.0.0)
- **Fixes minor inconsistencies**: Corrects hyphenation (opt-in, future-proof) for consistency

## Motivation

While reviewing the README, I noticed that the version jump from `.v18` to `.v26` could be confusing to developers unfamiliar with Apple's 2025 unified versioning system. The scope parameter explanation was also a bit terse and could benefit from additional context.

## Changes

1. Added a NOTE callout explaining the v26 unified versioning system right after the IMPORTANT callout about explicit opt-in
2. Enhanced the scope parameter section with a bold heading and inline code comment
3. Updated the library author version range example to use a more realistic current version range
4. Minor grammar/style improvements (hyphenation consistency)

## Test plan

- [x] Read through the updated README
- [x] Verified all markdown formatting renders correctly
- [x] Confirmed links still work
- [x] No code changes, documentation only

Generated with Claude Code