### PR TITLE
Add explanation to 'Cannot implement' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ View Types
 
 ### Cannot implement
 
+The following SwiftUI views cannot be introspected because they either don't have a corresponding UIKit/AppKit backing view, or their backing type differs from what might be expected:
+
 SwiftUI | Affected Frameworks | Why
 --- | --- | ---
 Text | UIKit, AppKit | Not a UILabel / NSLabel


### PR DESCRIPTION
## Summary

Adds a brief introductory sentence to the "Cannot implement" section explaining why the listed SwiftUI views cannot be introspected.

## Changes

- Added explanatory text: "The following SwiftUI views cannot be introspected because they either don't have a corresponding UIKit/AppKit backing view, or their backing type differs from what might be expected:"

## Motivation

The "Cannot implement" section jumped directly into a table without context. This small addition helps users immediately understand what the table represents and why these views are listed, improving the documentation's clarity and user experience.

## Test plan

- [x] Verified markdown renders correctly
- [x] Confirmed the explanation is accurate
- [x] No code changes, documentation only

Generated with Claude Code