### PR TITLE
Fix memory leak in IntrospectionStore and dangling pointer in introspectionController

### DIFF
--- a/Sources/IntrospectionView.swift
+++ b/Sources/IntrospectionView.swift
@@ -132,6 +132,7 @@ struct IntrospectionView<Target: PlatformEntity>: PlatformViewControllerRepresen
 
 	static func dismantlePlatformViewController(_ controller: IntrospectionPlatformViewController, coordinator: Coordinator) {
 		controller.handler = nil
+		IntrospectionStore.shared.removeValue(forKey: controller.id)
 	}
 }
 
@@ -211,11 +212,11 @@ extension PlatformView {
 	fileprivate var introspectionController: IntrospectionPlatformViewController? {
 		get {
 			let key = unsafeBitCast(Selector(#function), to: UnsafeRawPointer.self)
-			return objc_getAssociatedObject(self, key) as? IntrospectionPlatformViewController
+			return (objc_getAssociatedObject(self, key) as? Weak<IntrospectionPlatformViewController>)?.wrappedValue
 		}
 		set {
 			let key = unsafeBitCast(Selector(#function), to: UnsafeRawPointer.self)
-			objc_setAssociatedObject(self, key, newValue, .OBJC_ASSOCIATION_ASSIGN)
+			objc_setAssociatedObject(self, key, Weak(wrappedValue: newValue), .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #441.

- **Clean up `IntrospectionStore` entries on dismantle:** `IntrospectionStore.shared` dictionary entries were never removed, causing unbounded growth over an app's lifetime. Now the entry is removed in `dismantlePlatformViewController` when the controller is torn down.
- **Fix dangling pointer in `introspectionController` associated object:** Replaced `OBJC_ASSOCIATION_ASSIGN` (unsafe unretained, no zeroing) with the existing `Weak<T>` box wrapper using `OBJC_ASSOCIATION_RETAIN_NONATOMIC`. The box is retained by the association, but its internal reference to the controller is `weak`, so it safely zeroes out on deallocation instead of leaving a dangling pointer.