### PR TITLE
CI: update iPadOS to 26.2, fix NavigationSplitView test sidebar visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           - { name: "iPadOS 16.4",      runtime: "iOS 16.4",       device: "iPad Pro (11-inch) (4th generation)" }
           - { name: "iPadOS 17.5",      runtime: "iOS 17.5",       device: "iPad Pro 11-inch (M4)" }
           - { name: "iPadOS 18.5",      runtime: "iOS 18.5",       device: "iPad Pro 11-inch (M4)",        runner: macos-15 }
-          - { name: "iPadOS 26.0",      runtime: "iOS 26.0",       device: "iPad Pro 11-inch (M4)" }
+          - { name: "iPadOS 26.2",      runtime: "iOS 26.2",       device: "iPad Pro 11-inch (M4)" }
           # macOS / macCatalyst
           - { name: "macCatalyst 15",  destination: "platform=macOS,variant=Mac Catalyst",  runner: macos-15 }
           - { name: "macCatalyst 26",  destination: "platform=macOS,variant=Mac Catalyst" }

--- a/Examples/Showcase/Showcase/Navigation.swift
+++ b/Examples/Showcase/Showcase/Navigation.swift
@@ -23,11 +23,7 @@ struct NavigationShowcase: View {
 			.navigationView(style: .columns),
 			on: .iOS(.v15, .v16, .v17, .v18, .v26), .visionOS(.v1, .v2, .v26)
 		) { splitViewController in
-			#if os(visionOS)
 			splitViewController.preferredDisplayMode = .oneBesideSecondary
-			#else
-			splitViewController.preferredDisplayMode = .oneOverSecondary
-			#endif
 		}
 		.introspect(.navigationView(style: .columns), on: .tvOS(.v15, .v16, .v17, .v18, .v26)) { navigationController in
 			navigationController.navigationBar.backgroundColor = .cyan

--- a/Tests/Tests/ViewTypes/NavigationViewWithColumnsStyleTests.swift
+++ b/Tests/Tests/ViewTypes/NavigationViewWithColumnsStyleTests.swift
@@ -52,7 +52,7 @@ struct NavigationViewWithColumnsStyleTests {
 			#if os(iOS)
 			// NB: this is necessary for ancestor introspection to work, because initially on iPad the "Customized" text isn't shown as it's hidden in the sidebar. This is why ancestor introspection is discouraged for most situations and it's opt-in.
 			.introspect(.navigationView(style: .columns), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
-				$0.preferredDisplayMode = .oneOverSecondary
+				$0.preferredDisplayMode = .oneBesideSecondary
 			}
 			#endif
 		}

--- a/Tests/Tests/ViewTypes/SearchFieldTests.swift
+++ b/Tests/Tests/ViewTypes/SearchFieldTests.swift
@@ -75,7 +75,7 @@ struct SearchFieldTests {
 			#if os(iOS)
 			// NB: this is necessary for introspection to work, because on iPad the search field is in the sidebar, which is initially hidden.
 			.introspect(.navigationView(style: .columns), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
-				$0.preferredDisplayMode = .oneOverSecondary
+				$0.preferredDisplayMode = .oneBesideSecondary
 			}
 			#endif
 		}
@@ -94,7 +94,7 @@ struct SearchFieldTests {
 				#if os(iOS)
 				// NB: this is necessary for introspection to work, because on iPad the search field is in the sidebar, which is initially hidden.
 				.introspect(.navigationView(style: .columns), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
-					$0.preferredDisplayMode = .oneOverSecondary
+					$0.preferredDisplayMode = .oneBesideSecondary
 				}
 				#endif
 			}
@@ -114,7 +114,7 @@ struct SearchFieldTests {
 			#if os(iOS)
 			// NB: this is necessary for introspection to work, because on iPad the search field is in the sidebar, which is initially hidden.
 			.introspect(.navigationView(style: .columns), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
-				$0.preferredDisplayMode = .oneOverSecondary
+				$0.preferredDisplayMode = .oneBesideSecondary
 			}
 			#endif
 		}
@@ -133,7 +133,7 @@ struct SearchFieldTests {
 				#if os(iOS)
 				// NB: this is necessary for introspection to work, because on iPad the search field is in the sidebar, which is initially hidden.
 				.introspect(.navigationView(style: .columns), on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
-					$0.preferredDisplayMode = .oneOverSecondary
+					$0.preferredDisplayMode = .oneBesideSecondary
 				}
 				#endif
 			}


### PR DESCRIPTION
- Update iPadOS CI matrix entry from 26.0 to 26.2
- Change `preferredDisplayMode` from `.oneOverSecondary` to `.oneBesideSecondary` in NavigationViewWithColumnsStyleTests and SearchFieldTests to fix sidebar visibility on iOS 26+