### PR TITLE
CI: fix 26.2 runtime checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,10 @@ jobs:
           max_attempts: 3
           command: |
             RUNTIME="${{ matrix.runtime }}"
-            if ! xcodes runtimes 2>/dev/null | grep -qF "$RUNTIME (Installed)"; then
-              sudo xcodes runtimes install "$RUNTIME" --aria2 $(which aria2c)
+            if xcrun simctl list runtimes -j | jq -e --arg name "$RUNTIME" '.runtimes[] | select(.isAvailable) | select(.name == $name)' >/dev/null; then
+              echo "Runtime '$RUNTIME' is already installed."
+            else
+              sudo xcodes runtimes install "$RUNTIME" --aria2 "$(which aria2c)"
             fi
 
       - name: Create Simulator


### PR DESCRIPTION
CI is failing before build/test on the 26.2 jobs.

Those runtimes are already on the macOS 26 image, but the install guard checks `xcodes runtimes`. On the latest runner image that check misses them, so the workflow tries to download the runtimes and fails while looking them up.

This uses `simctl` for the guard instead, which is what the next step already uses when it creates the simulator.