### PR TITLE
CI: install xcodes from upstream tap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v5
 
+      - name: Upgrade xcodes
+        run: brew upgrade xcodesorg/made/xcodes
+
       - name: Select Xcode
         run: sudo xcodes select ${{ matrix.xcode || '26.6' }}
 
@@ -132,6 +135,9 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
+
+      - name: Upgrade xcodes
+        run: brew upgrade xcodesorg/made/xcodes
 
       - name: Select Xcode
         run: sudo xcodes select 26.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install xcodes
-        run: brew install xcodesorg/made/xcodes
+        run: |
+          brew uninstall xcodes
+          brew install xcodesorg/made/xcodes
 
       - name: Select Xcode
         run: sudo xcodes select ${{ matrix.xcode || '26.6' }}
@@ -137,7 +139,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install xcodes
-        run: brew install xcodesorg/made/xcodes
+        run: |
+          brew uninstall xcodes
+          brew install xcodesorg/made/xcodes
 
       - name: Select Xcode
         run: sudo xcodes select 26.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v5
 
-      - name: Upgrade xcodes
-        run: brew upgrade xcodesorg/made/xcodes
+      - name: Install xcodes
+        run: brew install xcodesorg/made/xcodes
 
       - name: Select Xcode
         run: sudo xcodes select ${{ matrix.xcode || '26.6' }}
@@ -136,8 +136,8 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v5
 
-      - name: Upgrade xcodes
-        run: brew upgrade xcodesorg/made/xcodes
+      - name: Install xcodes
+        run: brew install xcodesorg/made/xcodes
 
       - name: Select Xcode
         run: sudo xcodes select 26.6


### PR DESCRIPTION
## Summary

- Replace the runner-provided xcodes formula with the xcodesorg/made tap formula before CI selects Xcode.
- Apply the install step in both CI jobs that call xcodes.