### PR TITLE
Stop hierarchy traversal after the first match

### DIFF
--- a/Sources/Introspect.swift
+++ b/Sources/Introspect.swift
@@ -171,19 +171,18 @@ extension PlatformEntity {
 
 		return commonAncestor
 			.allDescendants(between: backEntity~, and: frontEntity~)
-			.filter { !$0.isIntrospectionPlatformEntity }
-			.compactMap { $0 as? PlatformSpecificEntity }
-			.first
+			.first {
+				!$0.isIntrospectionPlatformEntity && $0 is PlatformSpecificEntity
+			} as? PlatformSpecificEntity
 	}
 
 	func ancestor<PlatformSpecificEntity: PlatformEntity>(
 		ofType type: PlatformSpecificEntity.Type
 	) -> PlatformSpecificEntity? {
 		self.ancestors
-			.lazy
-			.filter { !$0.isIntrospectionPlatformEntity }
-			.compactMap { $0 as? PlatformSpecificEntity }
-			.first
+			.first {
+				!$0.isIntrospectionPlatformEntity && $0 is PlatformSpecificEntity
+			} as? PlatformSpecificEntity
 	}
 }
 

--- a/Sources/ViewTypes/SearchField.swift
+++ b/Sources/ViewTypes/SearchField.swift
@@ -116,7 +116,7 @@ extension iOSViewVersion<SearchFieldType, UISearchBar> {
 
 	private static var selector: IntrospectionSelector<UISearchBar> {
 		.from(UINavigationController.self) {
-			$0.viewIfLoaded?.allDescendants.lazy.compactMap { $0 as? UISearchBar }.first
+			$0.viewIfLoaded?.allDescendants.first(where: { $0 is UISearchBar }) as? UISearchBar
 		}
 	}
 }
@@ -135,7 +135,7 @@ extension tvOSViewVersion<SearchFieldType, UISearchBar> {
 
 	private static var selector: IntrospectionSelector<UISearchBar> {
 		.from(UINavigationController.self) {
-			$0.viewIfLoaded?.allDescendants.lazy.compactMap { $0 as? UISearchBar }.first
+			$0.viewIfLoaded?.allDescendants.first(where: { $0 is UISearchBar }) as? UISearchBar
 		}
 	}
 }
@@ -148,7 +148,7 @@ extension visionOSViewVersion<SearchFieldType, UISearchBar> {
 
 	private static var selector: IntrospectionSelector<UISearchBar> {
 		.from(UINavigationController.self) {
-			$0.viewIfLoaded?.allDescendants.lazy.compactMap { $0 as? UISearchBar }.first
+			$0.viewIfLoaded?.allDescendants.first(where: { $0 is UISearchBar }) as? UISearchBar
 		}
 	}
 }

--- a/Tests/Tests/PlatformEntityTraversalTests.swift
+++ b/Tests/Tests/PlatformEntityTraversalTests.swift
@@ -1,0 +1,37 @@
+@testable import SwiftUIIntrospect
+import Testing
+
+@MainActor
+@Suite
+struct PlatformEntityTraversalTests {
+	@Test func ancestorLookupStopsAfterFirstMatch() {
+		let tail = Entity()
+		let match = MatchingEntity(ancestor: tail)
+		let entity = Entity(ancestor: match)
+
+		#expect(entity.ancestor(ofType: MatchingEntity.self) === match)
+		#expect(match.ancestorAccessCount == 0)
+	}
+
+	private class Entity: PlatformEntity {
+		typealias Base = Entity
+
+		private let storedAncestor: Entity?
+		private(set) var ancestorAccessCount = 0
+
+		init(ancestor: Entity? = nil) {
+			self.storedAncestor = ancestor
+		}
+
+		var ancestor: Entity? {
+			ancestorAccessCount += 1
+			return storedAncestor
+		}
+
+		var descendants: [Entity] { [] }
+
+		func isDescendant(of other: Entity) -> Bool { false }
+	}
+
+	private final class MatchingEntity: Entity {}
+}


### PR DESCRIPTION
## Context

While exercising search field introspection in a nested navigation hierarchy, I instrumented a cold lookup and found that traversal continued after the target had already been selected and customized.

For opaque, non-`Collection` sequences, `.lazy.compactMap(...).first` resolves to the eager `Sequence.compactMap` overload, materializes an array, and only then reads `Collection.first`. The same eager behavior affected the shared receiver and ancestor lookup paths.

## Changes

- Use `Sequence.first(where:)` for receiver and ancestor lookup so traversal stops at the first eligible platform entity.
- Apply the same short-circuiting lookup to the iOS, tvOS, and visionOS search field selectors.
- Add a regression test that records whether ancestor traversal advances beyond the first matching entity.

The selected entity, marker exclusion, fallback order, and no-match behavior remain unchanged.

## Measured traversal work

The measurements count actual iterator yields in the selected successful cold lookup. Before and after runs selected the same `SwiftUI.UIKitSearchBar`, followed the same semantic route, preserved target correlation through delivery, and reported no diagnostic violations.

| Environment | Receiver | Search field hierarchy | Combined |
| --- | ---: | ---: | ---: |
| Xcode 26.5 / iOS 26.5 | 7 → 5 | 188 → 165 | 195 → 170 (-12.82%) |
| Xcode 27 beta 4 / iOS 27 | 7 → 5 | 186 → 161 | 193 → 166 (-13.99%) |

After the change, both traversals stop exactly at the selected target position. These figures describe deterministic hierarchy work removed; they do not claim a wall-clock improvement from simulator timing.

## Testing

- The regression test fails with the previous eager implementation (`1` post-match ancestor access) and passes with the short-circuiting implementation (`0`).
- Full test suite on iOS 26.5: 77 passed, 8 skipped, 0 failed.
- Full test suite on iOS 27: 77 passed, 8 skipped, 0 failed.
- Full test suite on macOS 26.4.1: 62 passed, 6 skipped, 0 failed.
