### PR TITLE
Stop hierarchy traversal after the first matching entity

### DIFF
--- a/Sources/Introspect.swift
+++ b/Sources/Introspect.swift
@@ -171,19 +171,25 @@ extension PlatformEntity {
 
 		return commonAncestor
 			.allDescendants(between: backEntity~, and: frontEntity~)
-			.filter { !$0.isIntrospectionPlatformEntity }
-			.compactMap { $0 as? PlatformSpecificEntity }
-			.first
+			.firstPlatformEntity(ofType: PlatformSpecificEntity.self)
 	}
 
 	func ancestor<PlatformSpecificEntity: PlatformEntity>(
 		ofType type: PlatformSpecificEntity.Type
 	) -> PlatformSpecificEntity? {
 		self.ancestors
-			.lazy
-			.filter { !$0.isIntrospectionPlatformEntity }
-			.compactMap { $0 as? PlatformSpecificEntity }
-			.first
+			.firstPlatformEntity(ofType: PlatformSpecificEntity.self)
+	}
+}
+
+extension Sequence where Element: PlatformEntity {
+	@MainActor
+	func firstPlatformEntity<PlatformSpecificEntity: PlatformEntity>(
+		ofType type: PlatformSpecificEntity.Type
+	) -> PlatformSpecificEntity? {
+		self.first {
+			$0 is PlatformSpecificEntity && !$0.isIntrospectionPlatformEntity
+		} as? PlatformSpecificEntity
 	}
 }
 

--- a/Sources/ViewTypes/SearchField.swift
+++ b/Sources/ViewTypes/SearchField.swift
@@ -116,7 +116,7 @@ extension iOSViewVersion<SearchFieldType, UISearchBar> {
 
 	private static var selector: IntrospectionSelector<UISearchBar> {
 		.from(UINavigationController.self) {
-			$0.viewIfLoaded?.allDescendants.lazy.compactMap { $0 as? UISearchBar }.first
+			$0.viewIfLoaded?.allDescendants.firstPlatformEntity(ofType: UISearchBar.self)
 		}
 	}
 }
@@ -135,7 +135,7 @@ extension tvOSViewVersion<SearchFieldType, UISearchBar> {
 
 	private static var selector: IntrospectionSelector<UISearchBar> {
 		.from(UINavigationController.self) {
-			$0.viewIfLoaded?.allDescendants.lazy.compactMap { $0 as? UISearchBar }.first
+			$0.viewIfLoaded?.allDescendants.firstPlatformEntity(ofType: UISearchBar.self)
 		}
 	}
 }
@@ -148,7 +148,7 @@ extension visionOSViewVersion<SearchFieldType, UISearchBar> {
 
 	private static var selector: IntrospectionSelector<UISearchBar> {
 		.from(UINavigationController.self) {
-			$0.viewIfLoaded?.allDescendants.lazy.compactMap { $0 as? UISearchBar }.first
+			$0.viewIfLoaded?.allDescendants.firstPlatformEntity(ofType: UISearchBar.self)
 		}
 	}
 }

--- a/Tests/Tests/PlatformEntityTraversalTests.swift
+++ b/Tests/Tests/PlatformEntityTraversalTests.swift
@@ -1,0 +1,76 @@
+@_spi(Internals) @testable import SwiftUIIntrospect
+import Testing
+
+@MainActor
+@Suite
+struct PlatformEntityTraversalTests {
+	@Test func ancestorLookupStopsAfterFirstMatch() {
+		let match = MatchingEntity(ancestor: Entity())
+		let entity = Entity(ancestor: match)
+
+		#expect(entity.ancestor(ofType: MatchingEntity.self) === match)
+		#expect(match.ancestorAccessCount == 0)
+	}
+
+	@Test func boundedDescendantLookupStopsAfterFirstMatch() {
+		let back = Entity()
+		let match = MatchingEntity()
+		let tail = Entity()
+		let front = Entity()
+		let root = Entity(descendants: [back, match, tail, front])
+
+		let result = root
+			.allDescendants(between: back, and: front)
+			.firstPlatformEntity(ofType: MatchingEntity.self)
+
+		#expect(result === match)
+		#expect(tail.descendantsAccessCount == 0)
+	}
+
+	@Test func descendantLookupStopsAfterFirstMatch() {
+		let match = MatchingEntity()
+		let tail = Entity()
+		let root = Entity(descendants: [Entity(), match, tail])
+		let descendants = root.allDescendants
+
+		#expect(descendants.firstPlatformEntity(ofType: MatchingEntity.self) === match)
+		#expect(tail.descendantsAccessCount == 0)
+	}
+
+	@Test func lookupSkipsIntrospectionEntities() {
+		let marker = MatchingEntity()
+		let match = MatchingEntity()
+		let entities: [Entity] = [marker, match]
+		marker.isIntrospectionPlatformEntity = true
+
+		#expect(entities.firstPlatformEntity(ofType: MatchingEntity.self) === match)
+	}
+
+	private class Entity: PlatformEntity {
+		typealias Base = Entity
+
+		private let storedAncestor: Entity?
+		private let storedDescendants: [Entity]
+		private(set) var ancestorAccessCount = 0
+		private(set) var descendantsAccessCount = 0
+
+		init(ancestor: Entity? = nil, descendants: [Entity] = []) {
+			self.storedAncestor = ancestor
+			self.storedDescendants = descendants
+		}
+
+		var ancestor: Entity? {
+			ancestorAccessCount += 1
+			return storedAncestor
+		}
+
+		var descendants: [Entity] {
+			descendantsAccessCount += 1
+			return storedDescendants
+		}
+
+		func isDescendant(of other: Entity) -> Bool { false }
+	}
+
+	private final class MatchingEntity: Entity {}
+}


### PR DESCRIPTION
## Background

While reviewing the internal hierarchy traversal used for platform entity lookup, I noticed that several first-match lookup paths were implemented using `.lazy.compactMap(...).first`.

For the opaque, non-`Collection` sequences returned by these traversal helpers, this resolves to the eager `Sequence.compactMap` overload, consuming the remaining elements before `.first` is read.

Since SwiftUI Introspect only uses the first matching platform entity, traversal after that match is unnecessary. An iterator probe confirmed that the affected paths continued advancing after the target had already been found.

## Changes

- Stop shared receiver and ancestor lookup at the first matching platform entity.
- Apply the same short-circuiting lookup to the iOS, tvOS, and visionOS search field selectors.
- Add regression coverage for ancestor, bounded descendant, and plain descendant traversal.

The selected entity, introspection marker exclusion, fallback order, and no-match behavior remain unchanged.

## Validation

The measurements below count actual iterator yields during the same successful nested search field lookup. Both implementations selected the same `UISearchBar`.

| Environment | Receiver | Search field hierarchy | Combined |
| --- | ---: | ---: | ---: |
| Xcode 26.5 / iOS 26.5 | 7 → 5 | 188 → 165 | 195 → 170 |
| Xcode 27 beta 4 / iOS 27 | 7 → 5 | 186 → 161 | 193 → 166 |

- Regression tests fail with the previous eager lookup and pass with the short-circuiting implementation.
- Full test suites pass on iOS 26.5, iOS 27, and macOS.
